### PR TITLE
Fluentmigrator.Runner support for multiple assemblies at a time

### DIFF
--- a/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
+++ b/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Generators\Firebird\FirebirdColumn.cs" />
     <Compile Include="Generators\Firebird\FirebirdGenerator.cs" />
     <Compile Include="Generators\Firebird\FirebirdTruncator.cs" />
+    <Compile Include="MigrationAssemblyInfo.cs" />
     <Compile Include="Processors\Firebird\FirebirdProcessedExpression.cs" />
     <Compile Include="Generators\Firebird\FirebirdQuoter.cs" />
     <Compile Include="Generators\Firebird\FirebirdTypeMap.cs" />

--- a/src/FluentMigrator.Runner/IMigrationRunner.cs
+++ b/src/FluentMigrator.Runner/IMigrationRunner.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Reflection;
 
 namespace FluentMigrator.Runner
@@ -5,7 +6,7 @@ namespace FluentMigrator.Runner
     public interface IMigrationRunner
     {
         IMigrationProcessor Processor { get; }
-        Assembly MigrationAssembly { get; }
+        ICollection<MigrationAssemblyInfo> MigrationAssemblies { get; }
         void Up(IMigration migration);
         void MigrateUp();
         void MigrateUp(long version);

--- a/src/FluentMigrator.Runner/MigrationAssemblyInfo.cs
+++ b/src/FluentMigrator.Runner/MigrationAssemblyInfo.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace FluentMigrator.Runner
+{
+    public class MigrationAssemblyInfo
+    {
+        public Assembly Assembly { get;set; }
+        public string @Namespace { get; set; }
+    }
+}

--- a/src/FluentMigrator.Runner/ProfileLoader.cs
+++ b/src/FluentMigrator.Runner/ProfileLoader.cs
@@ -12,14 +12,14 @@ namespace FluentMigrator.Runner
         public ProfileLoader(IRunnerContext runnerContext, IMigrationRunner runner, IMigrationConventions conventions)
         {
             Runner = runner;
-            Assembly = runner.MigrationAssembly;
+            Assemblies = runner.MigrationAssemblies;
             Profile = runnerContext.Profile;
             Conventions = conventions;
 
             Initialize();
         }
 
-        private Assembly Assembly { get; set; }
+        private ICollection<MigrationAssemblyInfo> Assemblies { get; set; }
         private string Profile { get; set; }
         protected IMigrationConventions Conventions { get; set; }
         private IMigrationRunner Runner { get; set; }
@@ -31,7 +31,7 @@ namespace FluentMigrator.Runner
             _profiles = new List<IMigration>();
 
             if (!string.IsNullOrEmpty(Profile))
-                _profiles = FindProfilesIn(Assembly, Profile);
+                _profiles = Assemblies.SelectMany( r => FindProfilesIn(r.Assembly, Profile) );
         }
 
         public IEnumerable<IMigration> FindProfilesIn(Assembly assembly, string profile)

--- a/src/FluentMigrator.Runner/VersionLoader.cs
+++ b/src/FluentMigrator.Runner/VersionLoader.cs
@@ -18,18 +18,27 @@ namespace FluentMigrator.Runner
         private IVersionInfo _versionInfo;
         private IMigrationConventions Conventions { get; set; }
         private IMigrationProcessor Processor { get; set; }
-        protected Assembly Assembly { get; set; }
+        protected ICollection<MigrationAssemblyInfo> Assemblies { get; set; }
         public IVersionTableMetaData VersionTableMetaData { get; private set; }
         public IMigrationRunner Runner { get; set; }
         public VersionSchemaMigration VersionSchemaMigration { get; private set; }
         public IMigration VersionMigration { get; private set; }
         public IMigration VersionUniqueMigration { get; private set; }
-        
+
         public VersionLoader(IMigrationRunner runner, Assembly assembly, IMigrationConventions conventions)
+            : this(
+                runner, 
+                new List<MigrationAssemblyInfo>() {new MigrationAssemblyInfo(){Assembly =  assembly} }, 
+                conventions)
+        {
+
+        }
+
+        public VersionLoader(IMigrationRunner runner, ICollection<MigrationAssemblyInfo> assemblies, IMigrationConventions conventions)
         {
             Runner = runner;
             Processor = runner.Processor;
-            Assembly = assembly;
+            Assemblies = assemblies;
 
             Conventions = conventions;
             VersionTableMetaData = GetVersionTableMetaData();
@@ -51,7 +60,7 @@ namespace FluentMigrator.Runner
 
         public IVersionTableMetaData GetVersionTableMetaData()
         {
-            Type matchedType = Assembly.GetExportedTypes().FirstOrDefault(t => Conventions.TypeIsVersionTableMetaData(t));
+            Type matchedType = Assemblies.SelectMany(r => r.Assembly.GetExportedTypes()).FirstOrDefault(t => Conventions.TypeIsVersionTableMetaData(t));
 
             if (matchedType == null)
             {

--- a/src/FluentMigrator.Tests/Unit/MigrationRunnerTests.cs
+++ b/src/FluentMigrator.Tests/Unit/MigrationRunnerTests.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using FluentMigrator.Expressions;
 using FluentMigrator.Infrastructure;
@@ -230,7 +231,7 @@ namespace FluentMigrator.Tests.Unit
         [Test]
         public void LoadsCorrectCallingAssembly()
         {
-            _runner.MigrationAssembly.ShouldBe(Assembly.GetAssembly(typeof(MigrationRunnerTests)));
+            _runner.MigrationAssemblies.FirstOrDefault().Assembly.ShouldBe(Assembly.GetAssembly(typeof(MigrationRunnerTests)));
         }
 
         [Test]

--- a/src/FluentMigrator.Tests/Unit/ProfileLoaderTests.cs
+++ b/src/FluentMigrator.Tests/Unit/ProfileLoaderTests.cs
@@ -20,7 +20,7 @@ namespace FluentMigrator.Tests.Unit
 
             _runnerContextMock.Setup(x => x.Profile).Returns(string.Empty);
 			//_runnerContextMock.VerifyGet(x => x.Profile).Returns(string.Empty);
-			_runnerMock.SetupGet(x => x.MigrationAssembly).Returns(typeof(MigrationRunnerTests).Assembly);
+			_runnerMock.SetupGet(x => x.MigrationAssemblies).Returns(new [] { new MigrationAssemblyInfo(){ Assembly = typeof(MigrationRunnerTests).Assembly }  }  );
 
 			var profileLoader = new ProfileLoader(_runnerContextMock.Object, _runnerMock.Object, _conventionsMock.Object);
 


### PR DESCRIPTION
Added support for FluentMigrator.Runner to proccess multiple assemblies at a time, passed as a collection of MigrationAssemblyInfo packages. Kept compatibility with older code as existing constructors were replaced to point to new constructors.

Also fixed the test, which pass. Extensive test were not created/performed.