### PR TITLE
Fixed some bugs related to Firebird and SqlSchemaDumper

### DIFF
--- a/src/FluentMigrator.Runner/Generators/Firebird/FirebirdTypeMap.cs
+++ b/src/FluentMigrator.Runner/Generators/Firebird/FirebirdTypeMap.cs
@@ -8,6 +8,7 @@ namespace FluentMigrator.Runner.Generators.Firebird
         private const int DecimalCapacity = 19;
         private const int FirebirdMaxVarcharSize = 32765;
         private const int FirebirdMaxCharSize = 32767;
+        private const int FirebirdMaxUnicodeCharSize = 4000;
 
         protected override void SetupTypeMaps()
         {
@@ -17,26 +18,29 @@ namespace FluentMigrator.Runner.Generators.Firebird
              * */
             SetTypeMap(DbType.AnsiStringFixedLength, "CHAR(255)");
             SetTypeMap(DbType.AnsiStringFixedLength, "CHAR($size)", FirebirdMaxCharSize);
-            SetTypeMap(DbType.AnsiString, "BLOB SUB_TYPE TEXT");
+            SetTypeMap(DbType.AnsiString, "VARCHAR(255)");
             SetTypeMap(DbType.AnsiString, "VARCHAR($size)", FirebirdMaxVarcharSize);
+            SetTypeMap(DbType.AnsiString, "BLOB SUB_TYPE TEXT", int.MaxValue);
             SetTypeMap(DbType.Binary, "BLOB SUB_TYPE BINARY");
-            SetTypeMap(DbType.Boolean, "VARCHAR(10)"); //no direct boolean support
+            SetTypeMap(DbType.Binary, "BLOB SUB_TYPE BINARY", int.MaxValue);
+            SetTypeMap(DbType.Boolean, "CHAR(1)"); //no direct boolean support
             SetTypeMap(DbType.Byte, "SMALLINT");
-            SetTypeMap(DbType.Currency, "BIGINT");
+            SetTypeMap(DbType.Currency, "DECIMAL(18, 4)");
             SetTypeMap(DbType.Date, "DATE");
             SetTypeMap(DbType.DateTime, "TIMESTAMP");
             SetTypeMap(DbType.Decimal, "DECIMAL(14,5)");
             SetTypeMap(DbType.Decimal, "DECIMAL($precision,$size)", DecimalCapacity);
             SetTypeMap(DbType.Double, "DOUBLE PRECISION"); //64 bit double precision
-            SetTypeMap(DbType.Guid, "CHAR(16)"); //no guid support, "only" uuid is supported(via gen_uuid() built-in function)
+            SetTypeMap(DbType.Guid, "CHAR(16) CHARACTER SET OCTETS"); //no guid support, "only" uuid is supported(via gen_uuid() built-in function)
             SetTypeMap(DbType.Int16, "SMALLINT");
             SetTypeMap(DbType.Int32, "INTEGER");
             SetTypeMap(DbType.Int64, "BIGINT");
             SetTypeMap(DbType.Single, "FLOAT");
-            SetTypeMap(DbType.StringFixedLength, "CHAR(255)");
-            SetTypeMap(DbType.StringFixedLength, "CHAR($size)", FirebirdMaxCharSize);
-            SetTypeMap(DbType.String, "BLOB SUB_TYPE TEXT");
-            SetTypeMap(DbType.String, "VARCHAR($size)", FirebirdMaxVarcharSize);
+            SetTypeMap(DbType.StringFixedLength, "CHAR(255) CHARACTER SET UTF8"); //charset utf8 may fail at index creation, because of to small database pagesize
+            SetTypeMap(DbType.StringFixedLength, "CHAR($size) CHARACTER SET UTF8", FirebirdMaxUnicodeCharSize);
+            SetTypeMap(DbType.String, "VARCHAR(255) CHARACTER SET UTF8");
+            SetTypeMap(DbType.String, "VARCHAR($size) CHARACTER SET UTF8", FirebirdMaxUnicodeCharSize);
+            SetTypeMap(DbType.String, "BLOB SUB_TYPE TEXT", int.MaxValue);
             SetTypeMap(DbType.Time, "TIME");
         }
     }

--- a/src/FluentMigrator.Runner/Processors/Firebird/FirebirdProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/Firebird/FirebirdProcessor.cs
@@ -77,7 +77,7 @@ namespace FluentMigrator.Runner.Processors.Firebird
         public override bool IndexExists(string schemaName, string tableName, string indexName)
         {
             CheckTable(tableName);
-            return Exists("select rdb$index_name from rdb$indices where (rdb$relation_name = '{0}') and (rdb$index_name = '{1}') and (rdb$unique_flag IS NULL) and (rdb$foreign_key IS NULL)", FormatToSafeName(tableName), FormatToSafeName(indexName));
+            return Exists("select rdb$index_name from rdb$indices where (rdb$relation_name = '{0}') and (rdb$index_name = '{1}') and (rdb$system_flag <> 1 OR rdb$system_flag IS NULL) and (rdb$foreign_key IS NULL)", FormatToSafeName(tableName), FormatToSafeName(indexName));
         }
 
         public override bool SequenceExists(string schemaName, string sequenceName)
@@ -141,10 +141,12 @@ namespace FluentMigrator.Runner.Processors.Firebird
             base.CommitTransaction();
             EnsureConnectionIsClosed();
             ClearLocks();
+            processedExpressions.Clear();
         }
 
         public override void RollbackTransaction()
         {
+           
             base.RollbackTransaction();
 
             if (FBOptions.UndoEnabled && processedExpressions != null && processedExpressions.Count > 0)

--- a/src/FluentMigrator.SchemaDump/SchemaDumpers/SqlServerSchemaDumper.cs
+++ b/src/FluentMigrator.SchemaDump/SchemaDumpers/SqlServerSchemaDumper.cs
@@ -168,59 +168,52 @@ namespace FluentMigrator.SchemaDump.SchemaDumpers
 
         protected virtual DbType GetDbType(int typeNum)
         {
-            switch (typeNum)
+            var types = new Dictionary<int, DbType>()
             {
-                case 34: //'byte[]'
-                    return DbType.Byte;
-                case 35: //'string'
-                    return DbType.String;
-                case 36: //'System.Guid'
-                    return DbType.Guid;
-                case 48: //'byte'
-                    return DbType.Byte;
-                case 52: //'short'
-                    return DbType.Int16;
-                case 56: //'int'
-                    return DbType.Int32;
-                case 58: //'System.DateTime'
-                    return DbType.DateTime;
-                case 59: //'float'
-                    return DbType.Int64;
-                case 60: //'decimal'
-                    return DbType.Decimal;
-                case 61: //'System.DateTime'
-                    return DbType.DateTime;
-                case 62: //'double'
-                    return DbType.Double;
-                case 98: //'object'
-                    return DbType.Object;
-                case 99: //'string'
-                    return DbType.String;
-                case 104: //'bool'
-                    return DbType.Boolean;
-                case 106: //'decimal'
-                    return DbType.Decimal;
-                case 108: //'decimal'
-                    return DbType.Decimal;
-                case 122: //'decimal'
-                    return DbType.Decimal;
-                case 127: //'long'
-                    return DbType.Int64;
-                case 165: //'byte[]'
-                    return DbType.Byte;
-                case 167: //'string'
-                    return DbType.String;
-                case 173: //'byte[]'
-                    return DbType.Byte;
-                case 175: //'string'
-                    return DbType.String;
-                case 189: //'long'
-                    return DbType.Int64;
-                case 231: //'string'
-                case 239: //'string'
-                case 241: //'string'
-                default:
-                    return DbType.String;
+                {34, DbType.Binary},
+                {35, DbType.AnsiString},
+                {36, DbType.Guid},
+                {40, DbType.Date},
+                {41, DbType.Time},
+                {42, DbType.DateTime2},
+                {43, DbType.DateTimeOffset},
+                {48, DbType.Byte},
+                {52, DbType.Int16},
+                {56, DbType.Int32},
+                //{58, DbType.}, //smalldatetime
+                {59, DbType.Single},
+                {60, DbType.Currency},
+                {61, DbType.DateTime},
+                {62, DbType.Double},
+                //{98, DbType.}, //sql_variant
+                {99, DbType.String},
+                {104, DbType.Boolean},
+                {106, DbType.Decimal},
+                //{108, DbType.}, //numeric
+                //{122, DbType.}, //smallmoney
+                {127, DbType.Int64},
+                //{240, DbType.}, //hierarchyid
+                //{240, DbType.}, //geometry
+                //{240, DbType.}, //geography
+                {165, DbType.Binary},
+                {167, DbType.AnsiString},
+                {173, DbType.Binary},
+                {175, DbType.AnsiStringFixedLength},
+                //{189, DbType.}, //Timestamp
+                {231, DbType.String},
+                {239, DbType.StringFixedLength},
+                {241, DbType.Xml}
+                //{231, DbType.} //Sysname
+            };
+
+            DbType value;
+            if (types.TryGetValue(typeNum, out value))
+            {
+                return value;
+            }
+            else
+            {
+                throw new KeyNotFoundException(typeNum + " was not found!");
             }
         }
 

--- a/src/FluentMigrator.SchemaDump/SchemaDumpers/SqlServerSchemaDumper.cs
+++ b/src/FluentMigrator.SchemaDump/SchemaDumpers/SqlServerSchemaDumper.cs
@@ -107,7 +107,7 @@ namespace FluentMigrator.SchemaDump.SchemaDumpers
                 LEFT JOIN sys.default_constraints def ON c.default_object_id = def.object_id
                 LEFT JOIN sys.key_constraints pk ON t.object_id = pk.parent_object_id AND pk.type = 'PK'
                 LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu ON t.name = kcu.TABLE_NAME AND c.name = kcu.COLUMN_NAME AND pk.name = kcu.CONSTRAINT_NAME
-                ORDER BY t.name, c.name";
+                ORDER BY t.name, c.column_id";
             DataSet ds = Read(query);
             DataTable dt = ds.Tables[0];
             IList<TableDefinition> tables = new List<TableDefinition>();

--- a/src/FluentMigrator.SchemaDump/SchemaDumpers/SqlServerSchemaDumper.cs
+++ b/src/FluentMigrator.SchemaDump/SchemaDumpers/SqlServerSchemaDumper.cs
@@ -339,13 +339,13 @@ namespace FluentMigrator.SchemaDump.SchemaDumpers
                 ms = (from m in d.ForeignColumns
                       where m == dr["FK_Table"].ToString()
                       select m).ToList();
-                if (ms.Count == 0) d.ForeignColumns.Add(dr["FK_Table"].ToString());
+                if (ms.Count == 0) d.ForeignColumns.Add(dr["FK_Column"].ToString());
 
                 // Primary Columns
                 ms = (from m in d.PrimaryColumns
                       where m == dr["PK_Table"].ToString()
                       select m).ToList();
-                if (ms.Count == 0) d.PrimaryColumns.Add(dr["PK_Table"].ToString());
+                if (ms.Count == 0) d.PrimaryColumns.Add(dr["PK_Column"].ToString());
             }
 
             return keys;

--- a/src/FluentMigrator.Tests/Unit/Generators/Firebird/FirebirdGeneratorTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/Firebird/FirebirdGeneratorTests.cs
@@ -28,7 +28,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Firebird
             string tableName = "NewTable";
             CreateTableExpression expression = GetCreateTableExpression(tableName);
             string sql = generator.Generate(expression);
-            sql.ShouldBe("CREATE TABLE \"NewTable\" (\"ColumnName1\" BLOB SUB_TYPE TEXT NOT NULL, \"ColumnName2\" INTEGER NOT NULL)");
+            sql.ShouldBe("CREATE TABLE \"NewTable\" (\"ColumnName1\" VARCHAR(255) CHARACTER SET UTF8 NOT NULL, \"ColumnName2\" INTEGER NOT NULL)");
         }
 
         [Test]
@@ -38,7 +38,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Firebird
             CreateTableExpression expression = GetCreateTableExpression(tableName);
             expression.SchemaName = "wibble";
             string sql = generator.Generate(expression);
-            sql.ShouldBe("CREATE TABLE \"NewTable\" (\"ColumnName1\" BLOB SUB_TYPE TEXT NOT NULL, \"ColumnName2\" INTEGER NOT NULL)");
+            sql.ShouldBe("CREATE TABLE \"NewTable\" (\"ColumnName1\" VARCHAR(255) CHARACTER SET UTF8 NOT NULL, \"ColumnName2\" INTEGER NOT NULL)");
         }
 
         [Test]
@@ -48,7 +48,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Firebird
             CreateTableExpression expression = GetCreateTableExpression(tableName);
             expression.Columns[0].IsPrimaryKey = true;
             string sql = generator.Generate(expression);
-            sql.ShouldBe("CREATE TABLE \"NewTable\" (\"ColumnName1\" BLOB SUB_TYPE TEXT NOT NULL, \"ColumnName2\" INTEGER NOT NULL, PRIMARY KEY (\"ColumnName1\"))");
+            sql.ShouldBe("CREATE TABLE \"NewTable\" (\"ColumnName1\" VARCHAR(255) CHARACTER SET UTF8 NOT NULL, \"ColumnName2\" INTEGER NOT NULL, PRIMARY KEY (\"ColumnName1\"))");
         }
 
         [Test]
@@ -59,7 +59,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Firebird
             expression.Columns[0].IsPrimaryKey = true;
             expression.Columns[0].PrimaryKeyName = "PK_NewTable";
             string sql = generator.Generate(expression);
-            sql.ShouldBe("CREATE TABLE \"NewTable\" (\"ColumnName1\" BLOB SUB_TYPE TEXT NOT NULL, \"ColumnName2\" INTEGER NOT NULL, CONSTRAINT \"PK_NewTable\" PRIMARY KEY (\"ColumnName1\"))");
+            sql.ShouldBe("CREATE TABLE \"NewTable\" (\"ColumnName1\" VARCHAR(255) CHARACTER SET UTF8 NOT NULL, \"ColumnName2\" INTEGER NOT NULL, CONSTRAINT \"PK_NewTable\" PRIMARY KEY (\"ColumnName1\"))");
         }
 
         [Test]
@@ -69,7 +69,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Firebird
             CreateTableExpression expression = GetCreateTableExpression(tableName);
             expression.Columns[0].DefaultValue = "abc";
             string sql = generator.Generate(expression);
-            sql.ShouldBe("CREATE TABLE \"NewTable\" (\"ColumnName1\" BLOB SUB_TYPE TEXT DEFAULT 'abc' NOT NULL, \"ColumnName2\" INTEGER NOT NULL)");
+            sql.ShouldBe("CREATE TABLE \"NewTable\" (\"ColumnName1\" VARCHAR(255) CHARACTER SET UTF8 DEFAULT 'abc' NOT NULL, \"ColumnName2\" INTEGER NOT NULL)");
         }
 
         [Test]
@@ -80,7 +80,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Firebird
             expression.Columns[0].DefaultValue = null;
             var sql = generator.Generate(expression);
             sql.ShouldBe(
-                "CREATE TABLE \"NewTable\" (\"ColumnName1\" BLOB SUB_TYPE TEXT DEFAULT NULL NOT NULL, \"ColumnName2\" INTEGER NOT NULL)");
+                "CREATE TABLE \"NewTable\" (\"ColumnName1\" VARCHAR(255) CHARACTER SET UTF8 DEFAULT NULL NOT NULL, \"ColumnName2\" INTEGER NOT NULL)");
 
         }
 
@@ -92,7 +92,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Firebird
             expression.Columns[0].IsPrimaryKey = true;
             expression.Columns[1].IsPrimaryKey = true;
             string sql = generator.Generate(expression);
-            sql.ShouldBe("CREATE TABLE \"NewTable\" (\"ColumnName1\" BLOB SUB_TYPE TEXT NOT NULL, \"ColumnName2\" INTEGER NOT NULL, PRIMARY KEY (\"ColumnName1\", \"ColumnName2\"))");
+            sql.ShouldBe("CREATE TABLE \"NewTable\" (\"ColumnName1\" VARCHAR(255) CHARACTER SET UTF8 NOT NULL, \"ColumnName2\" INTEGER NOT NULL, PRIMARY KEY (\"ColumnName1\", \"ColumnName2\"))");
         }
 
         [Test]
@@ -104,7 +104,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Firebird
             expression.Columns[0].PrimaryKeyName = "wibble";
             expression.Columns[1].IsPrimaryKey = true;
             string sql = generator.Generate(expression);
-            sql.ShouldBe("CREATE TABLE \"NewTable\" (\"ColumnName1\" BLOB SUB_TYPE TEXT NOT NULL, \"ColumnName2\" INTEGER NOT NULL, CONSTRAINT \"wibble\" PRIMARY KEY (\"ColumnName1\", \"ColumnName2\"))");
+            sql.ShouldBe("CREATE TABLE \"NewTable\" (\"ColumnName1\" VARCHAR(255) CHARACTER SET UTF8 NOT NULL, \"ColumnName2\" INTEGER NOT NULL, CONSTRAINT \"wibble\" PRIMARY KEY (\"ColumnName1\", \"ColumnName2\"))");
         }
 
         [Test]
@@ -168,7 +168,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Firebird
             expression.TableName = tableName;
 
             string sql = generator.Generate(expression);
-            sql.ShouldBe("ALTER TABLE \"NewTable\" ADD \"NewColumn\" VARCHAR(5) NOT NULL");
+            sql.ShouldBe("ALTER TABLE \"NewTable\" ADD \"NewColumn\" VARCHAR(5) CHARACTER SET UTF8 NOT NULL");
         }
         
         [Test]


### PR DESCRIPTION
The Firebird processor had a bug which reverted successfull migrations when dispose on the processor is called at the end of a migration. This patch clears the stack of the changes after commit, to prevent the execution of them at the rollback step (on dispose).

Additionally the SqlSchemaDumper has been improved to have a more correctly DbType mapping. But I don't know how I should map the remaining types.

Finally a bug in SqlSchemaDumper has been fixed which selected the wrong column at the foreignkey extraction part.