### PR TITLE
Allow CurrentUTCDateTime SystemMethods in SQLLite

### DIFF
--- a/src/FluentMigrator.Runner/Generators/SQLite/SqliteColumn.cs
+++ b/src/FluentMigrator.Runner/Generators/SQLite/SqliteColumn.cs
@@ -43,6 +43,7 @@ namespace FluentMigrator.Runner.Generators.SQLite
         {
             switch (systemMethod)
             {
+                case SystemMethods.CurrentUTCDateTime:
                 case SystemMethods.CurrentDateTime:
                     return "CURRENT_TIMESTAMP";
             }


### PR DESCRIPTION
CURRENT_TIMESTAMP is actually UTC time - I'm not sure what would be best to handle local time in SQL Lite.