### PR TITLE
Support for multiple databases (internal only, not exposed through console)

### DIFF
--- a/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
+++ b/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
@@ -114,7 +114,6 @@
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.configuration" />
-    <Reference Include="System.Transactions" />
     <Reference Include="System.Xml.Linq">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>

--- a/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
+++ b/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
@@ -114,6 +114,7 @@
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.configuration" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Xml.Linq">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
@@ -223,6 +224,7 @@
     <Compile Include="Processors\Jet\JetProcessor.cs" />
     <Compile Include="Processors\Jet\JetProcessorFactory.cs" />
     <Compile Include="Processors\MigrationProcessorFactory.cs" />
+    <Compile Include="Processors\MultiDatabaseMigrationProcessor.cs" />
     <Compile Include="Processors\MySql\MySqlDbFactory.cs" />
     <Compile Include="Processors\MySql\MySqlProcessor.cs" />
     <Compile Include="Processors\MySql\MySqlProcessorFactory.cs" />

--- a/src/FluentMigrator.Runner/Processors/MultiDatabaseMigrationProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/MultiDatabaseMigrationProcessor.cs
@@ -1,0 +1,290 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using FluentMigrator.Builders.Execute;
+using FluentMigrator.Expressions;
+
+namespace FluentMigrator.Runner.Processors {
+    public class MultiDatabaseMigrationProcessor : IMultiDatabaseMigrationProcessor {
+        public IMigrationProcessor DefaultProcessor { get; private set; }
+        private readonly IDictionary<string, IMigrationProcessor> _otherProcessors;
+        private readonly IDictionary<IMigrationExpression, string> _expressionDatabaseKeys = new Dictionary<IMigrationExpression, string>();
+
+        public MultiDatabaseMigrationProcessor(IMigrationProcessor defaultProcessor, IDictionary<string, IMigrationProcessor> otherProcessors)
+        {
+            if (defaultProcessor == null) throw new ArgumentNullException("defaultProcessor");
+            if (otherProcessors == null) throw new ArgumentNullException("otherProcessors");
+
+            DefaultProcessor = defaultProcessor;
+            _otherProcessors = otherProcessors;
+        }
+
+        public bool SchemaExists(string schemaName)
+        {
+            return DefaultProcessor.SchemaExists(schemaName);
+        }
+
+        public bool TableExists(string schemaName, string tableName)
+        {
+            return DefaultProcessor.TableExists(schemaName, tableName);
+        }
+
+        public bool ColumnExists(string schemaName, string tableName, string columnName)
+        {
+            return DefaultProcessor.ColumnExists(schemaName, tableName, columnName);
+        }
+
+        public bool ConstraintExists(string schemaName, string tableName, string constraintName)
+        {
+            return DefaultProcessor.ConstraintExists(schemaName, tableName, constraintName);
+        }
+
+        public bool IndexExists(string schemaName, string tableName, string indexName)
+        {
+            return DefaultProcessor.IndexExists(schemaName, tableName, indexName);
+        }
+
+        public bool SequenceExists(string schemaName, string sequenceName)
+        {
+            return DefaultProcessor.SequenceExists(schemaName, sequenceName);
+        }
+
+        public bool DefaultValueExists(string schemaName, string tableName, string columnName, object defaultValue)
+        {
+            return DefaultProcessor.DefaultValueExists(schemaName, tableName, columnName, defaultValue);
+        }
+
+        public string DatabaseType
+        {
+            get { return DefaultProcessor.DatabaseType; }
+        }
+
+        public void Dispose()
+        {
+            DefaultProcessor.Dispose();
+            foreach (var pair in _otherProcessors)
+            {
+                pair.Value.Dispose();
+            }
+        }
+
+        public IMigrationProcessorOptions Options
+        {
+            get { return DefaultProcessor.Options; }
+        }
+
+        public string ConnectionString
+        {
+            get { return DefaultProcessor.ConnectionString; }
+        }
+
+        public void Execute(string template, params object[] args)
+        {
+            DefaultProcessor.Execute(template, args);
+        }
+
+        public DataSet ReadTableData(string schemaName, string tableName)
+        {
+            return DefaultProcessor.ReadTableData(schemaName, tableName);
+        }
+
+        public DataSet Read(string template, params object[] args)
+        {
+            return DefaultProcessor.Read(template, args);
+        }
+
+        public bool Exists(string template, params object[] args)
+        {
+            return DefaultProcessor.Exists(template, args);
+        }
+
+        public void BeginTransaction()
+        {
+            // this is imperfect, but significantly improving it would be too large of an effort
+            DefaultProcessor.BeginTransaction();
+            foreach (var processor in _otherProcessors)
+            {
+                processor.Value.BeginTransaction();
+            }
+        }
+
+        public void CommitTransaction()
+        {
+            DefaultProcessor.CommitTransaction();
+            foreach (var processor in _otherProcessors)
+            {
+                processor.Value.CommitTransaction();
+            }
+        }
+
+        public void RollbackTransaction()
+        {
+            DefaultProcessor.RollbackTransaction();
+            foreach (var processor in _otherProcessors)
+            {
+                processor.Value.RollbackTransaction();
+            }
+        }
+
+        public void Process(CreateSchemaExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void Process(DeleteSchemaExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void Process(AlterTableExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void Process(AlterColumnExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void Process(CreateTableExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void Process(CreateColumnExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void Process(DeleteTableExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void Process(DeleteColumnExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void Process(CreateForeignKeyExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void Process(DeleteForeignKeyExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void Process(CreateIndexExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void Process(DeleteIndexExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void Process(RenameTableExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void Process(RenameColumnExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void Process(InsertDataExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void Process(AlterDefaultConstraintExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void Process(PerformDBOperationExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void Process(DeleteDataExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void Process(UpdateDataExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void Process(AlterSchemaExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void Process(CreateSequenceExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void Process(DeleteSequenceExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void Process(CreateConstraintExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void Process(DeleteConstraintExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void Process(DeleteDefaultConstraintExpression expression)
+        {
+            GetProcessor(expression).Process(expression);
+        }
+
+        public void AssignDatabaseKey(IMigrationExpression expression, string databaseKey)
+        {
+            if (!_otherProcessors.ContainsKey(databaseKey))
+                throw new ArgumentException("Database key '" + databaseKey + "' is not known.", "databaseKey");
+
+            _expressionDatabaseKeys[expression] = databaseKey;
+        }
+
+        public bool HasDatabaseKey(string databaseKey)
+        {
+            return _otherProcessors.ContainsKey(databaseKey);
+        }
+
+        public IEnumerable<string> GetDatabaseKeys()
+        {
+            return _otherProcessors.Keys;
+        }
+
+        public IMigrationProcessor GetProcessorByDatabaseKey(string databaseKey) 
+        {
+            IMigrationProcessor processor;
+            if (!_otherProcessors.TryGetValue(databaseKey, out processor))
+                throw new ArgumentException("Database key '" + databaseKey + "' is not known.", "databaseKey");
+
+            return processor;
+        }
+
+        private IMigrationProcessor GetProcessor(IMigrationExpression expression)
+        {
+            string databaseKey;
+            if (!_expressionDatabaseKeys.TryGetValue(expression, out databaseKey))
+                return DefaultProcessor;
+
+            return _otherProcessors[databaseKey];
+        }
+    }
+}

--- a/src/FluentMigrator.Runner/Processors/MultiDatabaseMigrationProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/MultiDatabaseMigrationProcessor.cs
@@ -251,6 +251,11 @@ namespace FluentMigrator.Runner.Processors {
             GetProcessor(expression).Process(expression);
         }
 
+        public void Process(string sql, IMigrationExpression expression)
+        {
+            GetProcessor(expression).Process(sql, expression);
+        }
+
         public void AssignDatabaseKey(IMigrationExpression expression, string databaseKey)
         {
             if (!_otherProcessors.ContainsKey(databaseKey))

--- a/src/FluentMigrator.Runner/Processors/ProcessorBase.cs
+++ b/src/FluentMigrator.Runner/Processors/ProcessorBase.cs
@@ -40,6 +40,11 @@ namespace FluentMigrator.Runner.Processors
             Options = options;
         }
 
+        public virtual void Process(string sql, IMigrationExpression expression)
+        {
+            Process(sql);
+        }
+
         public virtual void Process(CreateSchemaExpression expression)
         {
             Process(Generator.Generate(expression));

--- a/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -242,6 +242,7 @@
     <Compile Include="Unit\Builders\Alter\AlterColumnExpressionBuilderTests.cs" />
     <Compile Include="Unit\Builders\Alter\AlterExpressionRootTests.cs" />
     <Compile Include="Unit\Builders\Alter\AlterTableExpressionBuilderTests.cs" />
+    <Compile Include="Unit\Builders\InDatabase\InDatabaseExpressionRootTests.cs" />
     <Compile Include="Unit\Builders\Create\CreateColumnExpressionBuilderTests.cs" />
     <Compile Include="Unit\Builders\Create\CreateConstraintExpressionBuilderTests.cs" />
     <Compile Include="Unit\Builders\Create\CreateExpressionRootTests.cs" />
@@ -487,6 +488,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>

--- a/src/FluentMigrator.Tests/Integration/MigrationRunnerTests.cs
+++ b/src/FluentMigrator.Tests/Integration/MigrationRunnerTests.cs
@@ -1149,6 +1149,24 @@ namespace FluentMigrator.Tests.Integration
                 }, true, new[] { typeof(FirebirdProcessor) });
         }
 
+        [Test]
+        public void CanMigrateMultipleDatabases() {
+            ExecuteWithMultiDatabase(
+                processor => {
+                    var runner = new MigrationRunner(Assembly.GetExecutingAssembly(), _runnerContext, processor);
+                    var multi = (IMultiDatabaseMigrationProcessor)processor;
+
+                    runner.Up(new TestMultiDatabase());
+                    processor.TableExists("TestSchema", "TestTable1").ShouldBeTrue();
+                    multi.GetProcessorByDatabaseKey(AlternateDatabaseKey).TableExists("TestSchema", "TestTable2").ShouldBeTrue();
+
+                    runner.Down(new TestMultiDatabase());
+                    processor.TableExists("TestSchema", "TestTable1").ShouldBeFalse();
+                    multi.GetProcessorByDatabaseKey(AlternateDatabaseKey).TableExists("TestSchema", "TestTable2").ShouldBeFalse();
+                }
+            );
+        }
+
         private static MigrationRunner SetupMigrationRunner(IMigrationProcessor processor)
         {
             Assembly asm = typeof(MigrationRunnerTests).Assembly;
@@ -1604,6 +1622,30 @@ namespace FluentMigrator.Tests.Integration
         public override void Down()
         {
             Execute.Sql("select 2");
+        }
+    }
+
+    internal class TestMultiDatabase : Migration {
+        public override void Up() {
+            Create.Schema("TestSchema");
+            Create.Table("TestTable1").InSchema("TestSchema").WithColumn("Id").AsInt32();
+
+            InDatabase(IntegrationTestBase.AlternateDatabaseKey)
+                .Create.Schema("TestSchema");
+
+            InDatabase(IntegrationTestBase.AlternateDatabaseKey)
+                .Create.Table("TestTable2").InSchema("TestSchema").WithColumn("Id").AsInt32();
+        }
+
+        public override void Down() {
+            Delete.Table("TestTable1").InSchema("TestSchema");
+            Delete.Schema("TestSchema");
+
+            InDatabase(IntegrationTestBase.AlternateDatabaseKey)
+                .Delete.Table("TestTable2").InSchema("TestSchema");
+
+            InDatabase(IntegrationTestBase.AlternateDatabaseKey)
+                .Delete.Schema("TestSchema");
         }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Builders/InDatabase/InDatabaseExpressionRootTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Builders/InDatabase/InDatabaseExpressionRootTests.cs
@@ -1,0 +1,65 @@
+﻿#region License
+// 
+// Copyright (c) 2007-2009, Sean Chambers <schambers80@gmail.com>
+// Copyright (c) 2011, Grant Archibald
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+using System;
+using System.Linq;
+using FluentMigrator.Builders.InDatabase;
+using FluentMigrator.Infrastructure;
+using Moq;
+using NUnit.Framework;
+
+namespace FluentMigrator.Tests.Unit.Builders.InDatabase
+{
+    [TestFixture]
+    public class InDatabaseExpressionRootTests
+    {
+        [Test]
+        public void WillAssignCorrectDatabaseKeyToExpression()
+        {
+            var mock = new Mock<IMultiDatabaseMigrationProcessor>();
+            mock.Setup(x => x.HasDatabaseKey(It.IsAny<string>()))
+                .Returns(true);
+
+            var context = ExecuteTestMigration(mock.Object, "TestKey");
+
+            var expression = context.Expressions.Single();
+            mock.Verify(m => m.AssignDatabaseKey(expression, "TestKey"));
+        }
+
+        [Test]
+        public void WillThrowArgumentExceptionIfDatabaseKeyIsNotFoundInProcessors() {
+            var mock = new Mock<IMultiDatabaseMigrationProcessor>();
+            mock.Setup(x => x.HasDatabaseKey("TestKey"))
+                .Returns(false);
+
+            Assert.Throws<ArgumentException>(() => ExecuteTestMigration(mock.Object, "TestKey"));
+        }
+        
+        private MigrationContext ExecuteTestMigration(IMultiDatabaseMigrationProcessor processor, string databaseKey = null)
+        {
+            var context = new MigrationContext(new MigrationConventions(), processor, GetType().Assembly, null, "");
+            var expression = new InDatabaseExpressionRoot(context, databaseKey);
+
+            expression.Create.Table("Foo").WithColumn("Id").AsInt16();
+
+            return context;
+        }
+    }
+
+}

--- a/src/FluentMigrator.Tests/Unit/Expressions/ExecuteEmbeddedSqlExpressionTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Expressions/ExecuteEmbeddedSqlExpressionTests.cs
@@ -30,7 +30,7 @@ namespace FluentMigrator.Tests.Unit.Expressions
             var expression = new ExecuteEmbeddedSqlScriptExpression { SqlScript = testSqlScript, MigrationAssembly = Assembly.GetExecutingAssembly() };
 
             var processor = new Mock<IMigrationProcessor>();
-            processor.Setup(x => x.Execute(scriptContents)).Verifiable();
+            processor.Setup(x => x.Process(scriptContents, expression)).Verifiable();
 
             expression.ExecuteWith(processor.Object);
             processor.Verify();
@@ -41,7 +41,7 @@ namespace FluentMigrator.Tests.Unit.Expressions
         {
             var expression = new ExecuteEmbeddedSqlScriptExpression { SqlScript = testSqlScript.ToUpper(), MigrationAssembly = Assembly.GetExecutingAssembly() };
             var processor = new Mock<IMigrationProcessor>();
-            processor.Setup(x => x.Execute(scriptContents)).Verifiable();
+            processor.Setup(x => x.Process(scriptContents, expression)).Verifiable();
 
             expression.ExecuteWith(processor.Object);
             processor.Verify();
@@ -52,7 +52,7 @@ namespace FluentMigrator.Tests.Unit.Expressions
         {
             var expression = new ExecuteEmbeddedSqlScriptExpression { SqlScript = "InitialSchema.sql", MigrationAssembly = Assembly.GetExecutingAssembly() };
             var processor = new Mock<IMigrationProcessor>();
-            processor.Setup(x => x.Execute("InitialSchema")).Verifiable();
+            processor.Setup(x => x.Process("InitialSchema", expression)).Verifiable();
 
             expression.ExecuteWith(processor.Object);
             processor.Verify();
@@ -63,7 +63,7 @@ namespace FluentMigrator.Tests.Unit.Expressions
         {
             var expression = new ExecuteEmbeddedSqlScriptExpression { SqlScript = "FluentMigrator.Tests.EmbeddedResources.InitialSchema.sql", MigrationAssembly = Assembly.GetExecutingAssembly() };
             var processor = new Mock<IMigrationProcessor>();
-            processor.Setup(x => x.Execute("InitialSchema")).Verifiable();
+            processor.Setup(x => x.Process("InitialSchema", expression)).Verifiable();
 
             expression.ExecuteWith(processor.Object);
             processor.Verify();
@@ -76,7 +76,7 @@ namespace FluentMigrator.Tests.Unit.Expressions
             var processor = new Mock<IMigrationProcessor>();
 
             Assert.Throws<InvalidOperationException>(() => expression.ExecuteWith(processor.Object));
-            processor.Verify(x => x.Execute("NotUniqueResource"), Times.Never());
+            processor.Verify(x => x.Process("NotUniqueResource", expression), Times.Never());
         }
 
         [Test]

--- a/src/FluentMigrator.Tests/Unit/Expressions/ExecuteSqlScriptExpressionTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Expressions/ExecuteSqlScriptExpressionTests.cs
@@ -46,7 +46,7 @@ namespace FluentMigrator.Tests.Unit.Expressions
             var expression = new ExecuteSqlScriptExpression { SqlScript = testSqlScript };
 
             var processor = new Mock<IMigrationProcessor>();
-            processor.Setup(x => x.Execute(scriptContents)).Verifiable();
+            processor.Setup(x => x.Process(scriptContents, expression)).Verifiable();
 
             expression.ExecuteWith(processor.Object);
             processor.Verify();

--- a/src/FluentMigrator.Tests/Unit/Expressions/ExecuteSqlStatementExpressionTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Expressions/ExecuteSqlStatementExpressionTests.cs
@@ -42,7 +42,7 @@ namespace FluentMigrator.Tests.Unit.Expressions
             var expression = new ExecuteSqlStatementExpression() { SqlStatement = "INSERT INTO BLAH" };
 
             var processor = new Mock<IMigrationProcessor>();
-            processor.Setup(x => x.Execute(expression.SqlStatement)).Verifiable();
+            processor.Setup(x => x.Process(expression.SqlStatement, expression)).Verifiable();
 
             expression.ExecuteWith(processor.Object);
             processor.Verify();

--- a/src/FluentMigrator/Builders/InDatabase/AlternateDatabaseMigrationContext.cs
+++ b/src/FluentMigrator/Builders/InDatabase/AlternateDatabaseMigrationContext.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentMigrator.Expressions;
+using FluentMigrator.Infrastructure;
+
+namespace FluentMigrator.Builders.InDatabase
+{
+    public class AlternateDatabaseMigrationContext : MigrationContext
+    {
+        private readonly IMultiDatabaseMigrationProcessor _migrationProcessor;
+        private readonly string _databaseKey;
+
+        public AlternateDatabaseMigrationContext(IMigrationContext parent, IMultiDatabaseMigrationProcessor migrationProcessor, string databaseKey)
+            : base(parent.Conventions, migrationProcessor.GetProcessorByDatabaseKey(databaseKey), parent.MigrationAssembly, parent.ApplicationContext, migrationProcessor.ConnectionString)
+        {
+            _migrationProcessor = migrationProcessor;
+            _databaseKey = databaseKey;
+            Expressions = new InterceptingExpressionCollection(parent.Expressions, e => _migrationProcessor.AssignDatabaseKey(e, _databaseKey));
+        }
+
+        public override ICollection<IMigrationExpression> Expressions { get; set; }
+        
+        private class InterceptingExpressionCollection : ICollection<IMigrationExpression>
+        {
+            private readonly ICollection<IMigrationExpression> _parent;
+            private readonly Action<IMigrationExpression> _processBeforeAdd;
+
+            public InterceptingExpressionCollection(ICollection<IMigrationExpression> parent, Action<IMigrationExpression> processBeforeAdd)
+            {
+                _parent = parent;
+                _processBeforeAdd = processBeforeAdd;
+            }
+
+            public void Add(IMigrationExpression item) 
+            {
+                _processBeforeAdd(item);
+                _parent.Add(item);
+            }
+
+            public void Clear()
+            {
+                _parent.Clear();
+            }
+
+            public bool Contains(IMigrationExpression item)
+            {
+                return _parent.Contains(item);
+            }
+
+            public void CopyTo(IMigrationExpression[] array, int arrayIndex)
+            {
+                _parent.CopyTo(array, arrayIndex);
+            }
+
+            public int Count 
+            {
+                get { return _parent.Count; }
+            }
+
+            public bool IsReadOnly
+            {
+                get { return _parent.IsReadOnly; }
+            }
+
+            public bool Remove(IMigrationExpression item)
+            {
+                return _parent.Remove(item);
+            }
+
+            public IEnumerator<IMigrationExpression> GetEnumerator()
+            {
+                return _parent.GetEnumerator();
+            }
+
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() 
+            {
+                return _parent.GetEnumerator();
+            }
+        }
+    }
+}

--- a/src/FluentMigrator/Builders/InDatabase/IInDatabaseExpressionRoot.cs
+++ b/src/FluentMigrator/Builders/InDatabase/IInDatabaseExpressionRoot.cs
@@ -1,0 +1,53 @@
+﻿#region License
+// 
+// Copyright (c) 2007-2009, Sean Chambers <schambers80@gmail.com>
+// Copyright (c) 2011, Grant Archibald
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+
+using FluentMigrator.Builders.Alter;
+using FluentMigrator.Builders.Create;
+using FluentMigrator.Builders.Delete;
+using FluentMigrator.Builders.Execute;
+using FluentMigrator.Builders.Insert;
+using FluentMigrator.Builders.Rename;
+using FluentMigrator.Builders.Schema;
+using FluentMigrator.Builders.Update;
+
+namespace FluentMigrator.Builders.InDatabase
+{
+    /// <summary>
+    /// Defines fluent expressions that will be executed on a specific database
+    /// </summary>
+    public interface IInDatabaseExpressionRoot
+    {
+        IAlterExpressionRoot Alter { get; }
+
+        ICreateExpressionRoot Create { get; }
+
+        IDeleteExpressionRoot Delete { get; }
+
+        IRenameExpressionRoot Rename { get; }
+
+        IInsertExpressionRoot Insert { get; }
+
+        IExecuteExpressionRoot Execute { get; }
+
+        ISchemaExpressionRoot Schema { get; }
+
+        IUpdateExpressionRoot Update { get; }
+    }
+}

--- a/src/FluentMigrator/Builders/InDatabase/IInDatabaseExpressionRoot.cs
+++ b/src/FluentMigrator/Builders/InDatabase/IInDatabaseExpressionRoot.cs
@@ -17,11 +17,11 @@
 //
 #endregion
 
-
 using FluentMigrator.Builders.Alter;
 using FluentMigrator.Builders.Create;
 using FluentMigrator.Builders.Delete;
 using FluentMigrator.Builders.Execute;
+using FluentMigrator.Builders.IfDatabase;
 using FluentMigrator.Builders.Insert;
 using FluentMigrator.Builders.Rename;
 using FluentMigrator.Builders.Schema;
@@ -49,5 +49,7 @@ namespace FluentMigrator.Builders.InDatabase
         ISchemaExpressionRoot Schema { get; }
 
         IUpdateExpressionRoot Update { get; }
+
+        IIfDatabaseExpressionRoot IfDatabase(params string[] databaseType);
     }
 }

--- a/src/FluentMigrator/Builders/InDatabase/InDatabaseExpressionRoot.cs
+++ b/src/FluentMigrator/Builders/InDatabase/InDatabaseExpressionRoot.cs
@@ -1,0 +1,126 @@
+﻿#region License
+// 
+// Copyright (c) 2007-2009, Sean Chambers <schambers80@gmail.com>
+// Copyright (c) 2011, Grant Archibald
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+using System;
+using System.Linq;
+using FluentMigrator.Builders.Alter;
+using FluentMigrator.Builders.Create;
+using FluentMigrator.Builders.Delete;
+using FluentMigrator.Builders.Execute;
+using FluentMigrator.Builders.Insert;
+using FluentMigrator.Builders.Rename;
+using FluentMigrator.Builders.Schema;
+using FluentMigrator.Builders.Update;
+using FluentMigrator.Infrastructure;
+
+namespace FluentMigrator.Builders.InDatabase
+{
+    /// <summary>
+    /// Allows to apply expressions to a different (non-default) database
+    /// </summary>
+    public class InDatabaseExpressionRoot : IInDatabaseExpressionRoot
+    {
+        /// <summary>
+        /// The context to add expressions into (this context will use provided connection name).
+        /// </summary>
+        private readonly IMigrationContext _context;
+
+        /// <summary>Constructs a new instance of a <see cref="InDatabaseExpressionRoot"/> that will be using specified <paramref name="databaseKey" /></summary>
+        /// <param name="context">The parent context</param>
+        /// <param name="databaseKey">Database key to use (based on keys provided to <see cref="IMultiDatabaseMigrationProcessor" />)</param>
+        public InDatabaseExpressionRoot(IMigrationContext context, string databaseKey)
+        {
+            if (databaseKey == null)
+                throw new ArgumentNullException("databaseKey");
+
+            var processor = context.QuerySchema as IMultiDatabaseMigrationProcessor;
+            if (processor == null)
+                throw new ArgumentException("Multiple databases can only be used with IMultiDatabaseMigrationProcessor.");
+
+            if (!processor.HasDatabaseKey(databaseKey))
+            {
+                var message = string.Format("Database key '{0}' was not found. Available databases: '{1}'.", databaseKey, string.Join("', '", processor.GetDatabaseKeys().ToArray()));
+                throw new ArgumentException("context", message);
+            }
+
+            _context = new AlternateDatabaseMigrationContext(context, processor, databaseKey);
+        }
+
+        /// <summary>
+        /// Alter the schema of an existing object
+        /// </summary>
+        public IAlterExpressionRoot Alter
+        {
+            get { return new AlterExpressionRoot(_context); }
+        }
+
+        /// <summary>
+        /// Create a new database object
+        /// </summary>
+        public ICreateExpressionRoot Create
+        {
+            get { return new CreateExpressionRoot(_context); }
+        }
+
+        /// <summary>
+        /// Delete a database object, table, or row
+        /// </summary>
+        public IDeleteExpressionRoot Delete
+        {
+            get { return new DeleteExpressionRoot(_context); }
+        }
+
+        /// <summary>
+        /// Rename tables / columns
+        /// </summary>
+        public IRenameExpressionRoot Rename
+        {
+            get { return new RenameExpressionRoot(_context); }
+        }
+
+        /// <summary>
+        /// Insert data into a table
+        /// </summary>
+        public IInsertExpressionRoot Insert
+        {
+            get { return new InsertExpressionRoot(_context); }
+        }
+
+        /// <summary>
+        /// Execute SQL statements
+        /// </summary>
+        public IExecuteExpressionRoot Execute
+        {
+            get { return new ExecuteExpressionRoot(_context); }
+        }
+
+        public ISchemaExpressionRoot Schema
+        {
+            get { return new SchemaExpressionRoot(_context); }
+        }
+
+        /// <summary>
+        /// Update an existing row
+        /// </summary>
+        public IUpdateExpressionRoot Update
+        {
+            get { return new UpdateExpressionRoot(_context); }
+        }
+    }
+}

--- a/src/FluentMigrator/Builders/InDatabase/InDatabaseExpressionRoot.cs
+++ b/src/FluentMigrator/Builders/InDatabase/InDatabaseExpressionRoot.cs
@@ -23,6 +23,7 @@ using FluentMigrator.Builders.Alter;
 using FluentMigrator.Builders.Create;
 using FluentMigrator.Builders.Delete;
 using FluentMigrator.Builders.Execute;
+using FluentMigrator.Builders.IfDatabase;
 using FluentMigrator.Builders.Insert;
 using FluentMigrator.Builders.Rename;
 using FluentMigrator.Builders.Schema;
@@ -121,6 +122,11 @@ namespace FluentMigrator.Builders.InDatabase
         public IUpdateExpressionRoot Update
         {
             get { return new UpdateExpressionRoot(_context); }
+        }
+        
+        public IIfDatabaseExpressionRoot IfDatabase(params string[] databaseType)
+        {
+            return new IfDatabaseExpressionRoot(_context, databaseType);
         }
     }
 }

--- a/src/FluentMigrator/Expressions/ExecuteEmbeddedSqlScriptExpression.cs
+++ b/src/FluentMigrator/Expressions/ExecuteEmbeddedSqlScriptExpression.cs
@@ -25,10 +25,7 @@ namespace FluentMigrator.Expressions
                 sqlText = reader.ReadToEnd();
             }
 
-            // since all the Processors are using String.Format() in their Execute method
-            //  we need to escape the brackets with double brackets or else it throws an incorrect format error on the String.Format call
-            sqlText = sqlText.Replace("{", "{{").Replace("}", "}}");
-            processor.Execute(sqlText);
+            processor.Process(sqlText, this);
         }
 
         private string GetQualifiedResourcePath()

--- a/src/FluentMigrator/Expressions/ExecuteSqlScriptExpression.cs
+++ b/src/FluentMigrator/Expressions/ExecuteSqlScriptExpression.cs
@@ -32,10 +32,7 @@ namespace FluentMigrator.Expressions
             using (var reader = File.OpenText(SqlScript))
                 sqlText = reader.ReadToEnd();
 
-            // since all the Processors are using String.Format() in their Execute method
-            //  we need to escape the brackets with double brackets or else it throws an incorrect format error on the String.Format call
-            sqlText = sqlText.Replace("{", "{{").Replace("}", "}}");
-            processor.Execute(sqlText);
+            processor.Process(sqlText, this);
         }
 
         public override void ApplyConventions(IMigrationConventions conventions)

--- a/src/FluentMigrator/Expressions/ExecuteSqlStatementExpression.cs
+++ b/src/FluentMigrator/Expressions/ExecuteSqlStatementExpression.cs
@@ -28,10 +28,7 @@ namespace FluentMigrator.Expressions
 
         public override void ExecuteWith(IMigrationProcessor processor)
         {
-            // since all the Processors are using String.Format() in their Execute method
-            //  we need to escape the brackets with double brackets or else it throws an incorrect format error on the String.Format call
-            var sqlText = SqlStatement.Replace("{", "{{").Replace("}", "}}");
-            processor.Execute(sqlText);
+            processor.Process(SqlStatement, this);
         }
 
         public override void CollectValidationErrors(ICollection<string> errors)

--- a/src/FluentMigrator/FluentMigrator.csproj
+++ b/src/FluentMigrator/FluentMigrator.csproj
@@ -136,6 +136,9 @@
     <Compile Include="Builders\Alter\Table\IAlterTableAddColumOrAlterColumnSyntax.cs" />
     <Compile Include="Builders\Alter\Table\IAlterTableColumnAsTypeSyntax.cs" />
     <Compile Include="Builders\Alter\Table\IAlterTableColumnOptionOrAddColumnOrAlterColumnSyntax.cs" />
+    <Compile Include="Builders\InDatabase\AlternateDatabaseMigrationContext.cs" />
+    <Compile Include="Builders\InDatabase\InDatabaseExpressionRoot.cs" />
+    <Compile Include="Builders\InDatabase\IInDatabaseExpressionRoot.cs" />
     <Compile Include="Builders\Create\Column\ICreateColumnOptionOrForeignKeyCascadeSyntax.cs" />
     <Compile Include="Builders\Create\Column\ICreateColumnAsTypeOrInSchemaSyntax.cs" />
     <Compile Include="Builders\Create\Constraint\CreateConstraintExpressionBuilder.cs" />
@@ -186,6 +189,7 @@
     <Compile Include="Exceptions\FluentMigratorException.cs" />
     <Compile Include="Exceptions\ProcessorFactoryNotFoundException.cs" />
     <Compile Include="Exceptions\UndeterminableConnectionException.cs" />
+    <Compile Include="IMultiDatabaseMigrationProcessor.cs" />
     <Compile Include="Infrastructure\Extensions\ExtensionsForIMigrationInfo.cs" />
     <Compile Include="Infrastructure\IMigrationInfo.cs" />
     <Compile Include="Infrastructure\MigrationInfo.cs" />

--- a/src/FluentMigrator/IMigrationProcessor.cs
+++ b/src/FluentMigrator/IMigrationProcessor.cs
@@ -36,7 +36,7 @@ namespace FluentMigrator
         void BeginTransaction();
         void CommitTransaction();
         void RollbackTransaction();
-
+        
         void Process(CreateSchemaExpression expression);
         void Process(DeleteSchemaExpression expression);
         void Process(AlterTableExpression expression);
@@ -65,5 +65,7 @@ namespace FluentMigrator
         void Process(CreateConstraintExpression expression);
         void Process(DeleteConstraintExpression expression);
         void Process(DeleteDefaultConstraintExpression expression);
+
+        void Process(string sql, IMigrationExpression expression);
     }
 }

--- a/src/FluentMigrator/IMultiDatabaseMigrationProcessor.cs
+++ b/src/FluentMigrator/IMultiDatabaseMigrationProcessor.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using FluentMigrator.Expressions;
+
+namespace FluentMigrator {
+    public interface IMultiDatabaseMigrationProcessor : IMigrationProcessor {
+        IMigrationProcessor DefaultProcessor { get; }
+        void AssignDatabaseKey(IMigrationExpression expression, string databaseKey);
+        bool HasDatabaseKey(string databaseKey);
+        IEnumerable<string> GetDatabaseKeys();
+        IMigrationProcessor GetProcessorByDatabaseKey(string databaseKey);
+    }
+}

--- a/src/FluentMigrator/MigrationBase.cs
+++ b/src/FluentMigrator/MigrationBase.cs
@@ -18,6 +18,7 @@
 
 using FluentMigrator.Builders.Alter;
 using FluentMigrator.Builders.Create;
+using FluentMigrator.Builders.InDatabase;
 using FluentMigrator.Builders.IfDatabase;
 using FluentMigrator.Builders.Insert;
 using FluentMigrator.Builders.Rename;
@@ -101,6 +102,14 @@ namespace FluentMigrator
         public IIfDatabaseExpressionRoot IfDatabase(params string[] databaseType)
         {
             return new IfDatabaseExpressionRoot(_context, databaseType);
+        }
+
+        /// <summary>
+        /// Provides a way to execute parts of migration in context of a different database.
+        /// </summary>
+        public IInDatabaseExpressionRoot InDatabase(string databaseKey)
+        {
+            return new InDatabaseExpressionRoot(_context, databaseKey);
         }
     }
 }


### PR DESCRIPTION
This pull request adds support for migrating multiple related databases that have common versioning.
The database with version table is considered default and `Create` etc work as they did before, but the syntax below can be used to redirect certain changes to related databases.

**Syntax**
    
    InDatabase("Other")
        .Create.Table("Test").InSchema("test").WithColumn("Id").AsInt32();

**Notes on implementation**

1. This feature requires `MultiDatabaseMigrationProcessor` which wraps a set of other processors. This processor is currently not created when using console or MSBuild/NAnt tasks. The reason is that I do not need it at the moment (I use Runner manually), but I feel this pull request may be useful nevertheless.

2. Transaction support is rough -- failing transaction on one DB may not revert transactions in others. I do not see a perfect solution for that, unless something custom is done with MSDTC (do all DBs support `TransactionScope` properly?)

3. I tried to avoid breaking changes, but there is one breaking change where a new Process overload is added to the `IMigrationProcessor`. I hope everyone is using `ProcessorBase` and that would be OK.

3. New syntax makes old `IfDatabase` confusing. I would argue `IfDatabase` was already confusing and should be `IfEngine` or something like that. But it may also mean my extension should be renamed. I just did not have enough time for perfect naming.

4. Integration tests on MultiDB are only done in SQL Server 2008.

5. `IInDatabaseExpressionRoot` is a copy of `IIfDatabaseExpressionRoot`. Not sure if it should be reused instead (I noticed that it is not reused between `IfDatabase...` and similar code in `MigrationBase`).

6. I am not sure what level of XML comments is expected. I added some where similar classes had them or where it seemed useful. Let me know if more would be required.

7. For this, and for `InSchema` I feel supporting some kind of `using` may be a good idea. However this is probably not possible to implement without major changes.