### PR TITLE
Add options to generate migrations without database connection

### DIFF
--- a/src/FluentMigrator.Console/MigratorConsole.cs
+++ b/src/FluentMigrator.Console/MigratorConsole.cs
@@ -48,6 +48,8 @@ namespace FluentMigrator.Console
         public int Timeout;
         public bool Verbose;
         public long Version;
+        public long StartVersion;
+        public bool NoConnection;
         public string WorkingDirectory;
         public bool TransactionPerSession;
         public string ProviderSwitches;
@@ -130,6 +132,16 @@ namespace FluentMigrator.Console
                                             "version=",
                                             "The specific version to migrate. Default is 0, which will run all migrations.",
                                             v => { Version = long.Parse(v); }
+                                            },
+                                         {
+                                            "startVersion=",
+                                            "The specific version to start migrating from. Only used when NoConnection is true. Default is 0",
+                                            v => { StartVersion = long.Parse(v); }
+                                            },
+                                        {
+                                            "noConnection",
+                                            "Indicates that migrations will be generated without consulting a target database. Should only be used when generating an output file. ",
+                                            v => { NoConnection = NoConnection = true; }
                                             },
                                         {
                                             "verbose=",
@@ -293,6 +305,8 @@ namespace FluentMigrator.Console
                 NestedNamespaces = NestedNamespaces,
                 Task = Task,
                 Version = Version,
+                StartVersion = StartVersion,
+                NoConnection = NoConnection,
                 Steps = Steps,
                 WorkingDirectory = WorkingDirectory,
                 Profile = Profile,

--- a/src/FluentMigrator.Runner/ConnectionlessVersionLoader.cs
+++ b/src/FluentMigrator.Runner/ConnectionlessVersionLoader.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using FluentMigrator.Expressions;
+using FluentMigrator.Model;
+using FluentMigrator.Runner.Versioning;
+using FluentMigrator.VersionTableInfo;
+
+namespace FluentMigrator.Runner
+{
+    public class ConnectionlessVersionLoader: IVersionLoader
+    {
+        private bool _versionsLoaded;
+        public IMigrationRunner Runner { get; set; }
+        private IMigrationProcessor Processor { get; set; }
+        public Assembly Assembly { get; set; }
+        public IMigrationConventions Conventions { get; set; }
+        public long StartVersion { get; set; }
+        public long TargetVersion { get; set; }
+        public Versioning.IVersionInfo VersionInfo { get; set; }
+
+        public VersionTableInfo.IVersionTableMetaData VersionTableMetaData{get;set;}
+        public VersionSchemaMigration VersionSchemaMigration { get; private set; }
+        public IMigration VersionMigration { get; private set; }
+        public IMigration VersionUniqueMigration { get; private set; }
+        public IMigration VersionDescriptionMigration { get; private set; }
+
+        public ConnectionlessVersionLoader(IMigrationRunner runner, Assembly assembly, IMigrationConventions conventions, long startVersion, long targetVersion)
+        {
+            Runner = runner;
+            Assembly = assembly;
+            Conventions = conventions;
+            StartVersion = startVersion;
+            TargetVersion = targetVersion;
+
+            Processor = Runner.Processor;
+
+            VersionInfo = new VersionInfo();
+            VersionTableMetaData = GetVersionTableMetaData();
+            VersionMigration = new VersionMigration(VersionTableMetaData);
+            VersionSchemaMigration = new VersionSchemaMigration(VersionTableMetaData);
+            VersionUniqueMigration = new VersionUniqueMigration(VersionTableMetaData);
+            VersionDescriptionMigration = new VersionDescriptionMigration(VersionTableMetaData);
+
+            LoadVersionInfo();
+        }
+
+        public bool AlreadyCreatedVersionSchema
+        {
+            get 
+            {
+                return string.IsNullOrEmpty(VersionTableMetaData.SchemaName) ||
+                      Processor.SchemaExists(VersionTableMetaData.SchemaName);
+            }
+        }
+
+        public bool AlreadyCreatedVersionTable
+        {
+            get { return Processor.TableExists(VersionTableMetaData.SchemaName, VersionTableMetaData.TableName); }
+        }
+
+        public void DeleteVersion(long version)
+        {
+            var expression = new DeleteDataExpression { TableName = VersionTableMetaData.TableName, SchemaName = VersionTableMetaData.SchemaName };
+            expression.Rows.Add(new DeletionDataDefinition
+                                    {
+                                        new KeyValuePair<string, object>(VersionTableMetaData.ColumnName, version)
+                                    });
+            expression.ExecuteWith(Processor);
+        }
+
+        public VersionTableInfo.IVersionTableMetaData GetVersionTableMetaData()
+        {
+            var matchedType = Assembly.GetExportedTypes().FirstOrDefault(t => Conventions.TypeIsVersionTableMetaData(t));
+
+            if (matchedType == null)
+            {
+                return new DefaultVersionTableMetaData();
+            }
+
+            return (IVersionTableMetaData)Activator.CreateInstance(matchedType);
+        }
+
+        public void LoadVersionInfo()
+        {
+            if (_versionsLoaded)
+            {
+                return;
+            }
+
+            foreach (var migration in Runner.MigrationLoader.LoadMigrations())
+            {
+                if (migration.Key < StartVersion)
+                {
+                    VersionInfo.AddAppliedMigration(migration.Key);
+                }
+            }
+
+            _versionsLoaded = true;
+        }
+
+        public void RemoveVersionTable()
+        {
+            var expression = new DeleteTableExpression { TableName = VersionTableMetaData.TableName, SchemaName = VersionTableMetaData.SchemaName };
+            expression.ExecuteWith(Processor);
+
+            if (!string.IsNullOrEmpty(VersionTableMetaData.SchemaName))
+            {
+                var schemaExpression = new DeleteSchemaExpression { SchemaName = VersionTableMetaData.SchemaName };
+                schemaExpression.ExecuteWith(Processor);
+            }
+        }
+
+        public void UpdateVersionInfo(long version)
+        {
+            UpdateVersionInfo(version, null);
+        }
+
+        public void UpdateVersionInfo(long version, string description)
+        {
+            var dataExpression = new InsertDataExpression();
+            dataExpression.Rows.Add(CreateVersionInfoInsertionData(version, description));
+            dataExpression.TableName = VersionTableMetaData.TableName;
+            dataExpression.SchemaName = VersionTableMetaData.SchemaName;
+
+            dataExpression.ExecuteWith(Processor);
+        }
+
+        protected virtual InsertionDataDefinition CreateVersionInfoInsertionData(long version, string description)
+        {
+            return new InsertionDataDefinition
+                       {
+                           new KeyValuePair<string, object>(VersionTableMetaData.ColumnName, version),
+                           new KeyValuePair<string, object>(VersionTableMetaData.AppliedOnColumnName, DateTime.UtcNow),
+                           new KeyValuePair<string, object>(VersionTableMetaData.DescriptionColumnName, description),
+                       };
+        }
+    }
+}

--- a/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
+++ b/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
@@ -272,6 +272,9 @@
     <Compile Include="Processors\SqlServer\SqlServerProcessor.cs" />
     <Compile Include="ProfileLoader.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Generators\MigrationGeneratorFactory.cs" />
+    <Compile Include="Processors\ConnectionlessProcessor.cs" />
+    <Compile Include="ConnectionlessVersionLoader.cs" />
     <Compile Include="StopWatch.cs" />
     <Compile Include="Versioning\IVersionInfo.cs" />
     <Compile Include="Versioning\VersionInfo.cs" />

--- a/src/FluentMigrator.Runner/Generators/MigrationGeneratorFactory.cs
+++ b/src/FluentMigrator.Runner/Generators/MigrationGeneratorFactory.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using FluentMigrator.Runner.Extensions;
+using FluentMigrator.Runner.Processors;
+
+namespace FluentMigrator.Runner.Generators
+{ 
+     public class MigrationGeneratorFactory
+    {
+         private static readonly IDictionary<string, IMigrationGenerator> MigrationGenerators;
+
+        static MigrationGeneratorFactory()
+        {
+            Assembly assembly = typeof (IMigrationProcessorFactory).Assembly;
+
+            List<Type> types = assembly
+                .GetExportedTypes()
+                .Where(type => type.IsConcrete() && type.Is<IMigrationGenerator>())
+                .ToList();
+
+            var available = new SortedDictionary<string, IMigrationGenerator>();
+            foreach (Type type in types)
+            {
+                try
+                {
+                    var factory = (IMigrationGenerator) Activator.CreateInstance(type);
+                    available.Add(type.Name.Replace("Generator", ""), factory);
+                }
+                catch (Exception e)
+                {
+                    //can't add generators that require construtor parameters
+                }
+            }
+
+            MigrationGenerators = available;
+        }
+
+        public virtual IMigrationGenerator GetGenerator(string name)
+        {
+            return MigrationGenerators
+                .Where(pair => pair.Key.Equals(name, StringComparison.OrdinalIgnoreCase))
+                .Select(pair => pair.Value)
+                .FirstOrDefault();
+        }
+
+        public string ListAvailableProcessorTypes()
+        {
+            return string.Join(", ", MigrationGenerators.Keys.ToArray());
+        }
+    }
+}

--- a/src/FluentMigrator.Runner/IMigrationRunner.cs
+++ b/src/FluentMigrator.Runner/IMigrationRunner.cs
@@ -5,6 +5,8 @@ namespace FluentMigrator.Runner
     public interface IMigrationRunner : IMigrationScopeStarter
     {
         IMigrationProcessor Processor { get; }
+        IMigrationInformationLoader MigrationLoader { get; set; }
+
         Assembly MigrationAssembly { get; }
         void Up(IMigration migration);
         void Down(IMigration migration);

--- a/src/FluentMigrator.Runner/Initialization/IRunnerContext.cs
+++ b/src/FluentMigrator.Runner/Initialization/IRunnerContext.cs
@@ -30,6 +30,8 @@ namespace FluentMigrator.Runner.Initialization
         bool NestedNamespaces { get; set; }
         string Task { get; set; }
         long Version { get; set; }
+        long StartVersion { get; set; }
+        bool NoConnection { get; set; }
         int Steps { get; set; }
         string WorkingDirectory { get; set; }
         string Profile { get; set; }

--- a/src/FluentMigrator.Runner/Initialization/RunnerContext.cs
+++ b/src/FluentMigrator.Runner/Initialization/RunnerContext.cs
@@ -18,6 +18,8 @@ namespace FluentMigrator.Runner.Initialization
         public bool NestedNamespaces { get; set; }
         public string Task { get; set; }
         public long Version { get; set; }
+        public long StartVersion { get; set; }
+        public bool NoConnection { get; set; }
         public int Steps { get; set; }
         public string WorkingDirectory { get; set; }
         public string Profile { get; set; }

--- a/src/FluentMigrator.Runner/MigrationRunner.cs
+++ b/src/FluentMigrator.Runner/MigrationRunner.cs
@@ -84,10 +84,17 @@ namespace FluentMigrator.Runner
 
             _migrationScopeHandler = new MigrationScopeHandler(Processor);
             _migrationValidator = new MigrationValidator(_announcer, Conventions);
-            VersionLoader = new VersionLoader(this, _migrationAssembly, Conventions);
+
             MigrationLoader = new DefaultMigrationInformationLoader(Conventions, _migrationAssembly, runnerContext.Namespace, runnerContext.NestedNamespaces, runnerContext.Tags);
             ProfileLoader = new ProfileLoader(runnerContext, this, Conventions);
             MaintenanceLoader = new MaintenanceLoader(this, Conventions);
+
+            if (runnerContext.NoConnection){
+                VersionLoader = new ConnectionlessVersionLoader(this, _migrationAssembly, Conventions, runnerContext.StartVersion, runnerContext.Version);
+            }
+            else{
+                VersionLoader = new VersionLoader(this, _migrationAssembly, Conventions);
+            }
         }
 
         public IVersionLoader VersionLoader { get; set; }

--- a/src/FluentMigrator.Runner/Processors/ConnectionlessProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/ConnectionlessProcessor.cs
@@ -1,0 +1,236 @@
+﻿using System;
+using FluentMigrator.Runner.Initialization;
+
+namespace FluentMigrator.Runner.Processors
+{
+    public class ConnectionlessProcessor: IMigrationProcessor
+    {
+        public IMigrationGenerator Generator { get; set; }
+        public IRunnerContext Context { get; set; }
+        public IAnnouncer Announcer { get; set; }
+        public IMigrationProcessorOptions Options {get;set;}
+
+        public ConnectionlessProcessor(IMigrationGenerator generator, IRunnerContext context, IMigrationProcessorOptions options)
+        {
+            Generator = generator;
+            Context = context;
+            Announcer = Context.Announcer;
+            Options = options;
+        }
+
+        public string ConnectionString
+        {
+            get { return "No connection"; }
+        }
+
+        public void Execute(string template, params object[] args)
+        {
+            Process(string.Format(template, args));
+        }
+
+        public System.Data.DataSet ReadTableData(string schemaName, string tableName)
+        {
+            throw new NotImplementedException("Method is not supported by the connectionless processor");
+        }
+
+        public System.Data.DataSet Read(string template, params object[] args)
+        {
+            throw new NotImplementedException("Method is not supported by the connectionless processor");
+        }
+
+        public bool Exists(string template, params object[] args)
+        {
+            throw new NotImplementedException("Method is not supported by the connectionless processor");
+        }
+
+        public void BeginTransaction()
+        {
+            
+        }
+
+        public void CommitTransaction()
+        {
+            
+        }
+
+        public void RollbackTransaction()
+        {
+            
+        }
+
+        protected void Process(string sql)
+        {
+            Announcer.Sql(sql);
+        }
+
+        public void Process(Expressions.CreateSchemaExpression expression)
+        {
+            Process(Generator.Generate(expression));
+        }
+
+        public void Process(Expressions.DeleteSchemaExpression expression)
+        {
+            Process(Generator.Generate(expression));
+        }
+
+        public void Process(Expressions.AlterTableExpression expression)
+        {
+            Process(Generator.Generate(expression));
+        }
+
+        public void Process(Expressions.AlterColumnExpression expression)
+        {
+            Process(Generator.Generate(expression));
+        }
+
+        public void Process(Expressions.CreateTableExpression expression)
+        {
+            Process(Generator.Generate(expression));
+        }
+
+        public void Process(Expressions.CreateColumnExpression expression)
+        {
+            Process(Generator.Generate(expression));
+        }
+
+        public void Process(Expressions.DeleteTableExpression expression)
+        {
+            Process(Generator.Generate(expression));
+        }
+
+        public void Process(Expressions.DeleteColumnExpression expression)
+        {
+            Process(Generator.Generate(expression));
+        }
+
+        public void Process(Expressions.CreateForeignKeyExpression expression)
+        {
+            Process(Generator.Generate(expression));
+        }
+
+        public void Process(Expressions.DeleteForeignKeyExpression expression)
+        {
+            Process(Generator.Generate(expression));
+        }
+
+        public void Process(Expressions.CreateIndexExpression expression)
+        {
+            Process(Generator.Generate(expression));
+        }
+
+        public void Process(Expressions.DeleteIndexExpression expression)
+        {
+            Process(Generator.Generate(expression));
+        }
+
+        public void Process(Expressions.RenameTableExpression expression)
+        {
+            Process(Generator.Generate(expression));
+        }
+
+        public void Process(Expressions.RenameColumnExpression expression)
+        {
+            Process(Generator.Generate(expression));
+        }
+
+        public void Process(Expressions.InsertDataExpression expression)
+        {
+            Process(Generator.Generate(expression));
+        }
+
+        public void Process(Expressions.AlterDefaultConstraintExpression expression)
+        {
+            Process(Generator.Generate(expression));
+        }
+
+        public void Process(Builders.Execute.PerformDBOperationExpression expression)
+        {
+            Announcer.Say("Performing DB Operation");
+        }
+
+        public void Process(Expressions.DeleteDataExpression expression)
+        {
+            Process(Generator.Generate(expression));
+        }
+
+        public void Process(Expressions.UpdateDataExpression expression)
+        {
+            Process(Generator.Generate(expression));
+        }
+
+        public void Process(Expressions.AlterSchemaExpression expression)
+        {
+            Process(Generator.Generate(expression));
+        }
+
+        public void Process(Expressions.CreateSequenceExpression expression)
+        {
+            Process(Generator.Generate(expression));
+        }
+
+        public void Process(Expressions.DeleteSequenceExpression expression)
+        {
+            Process(Generator.Generate(expression));
+        }
+
+        public void Process(Expressions.CreateConstraintExpression expression)
+        {
+            Process(Generator.Generate(expression));
+        }
+
+        public void Process(Expressions.DeleteConstraintExpression expression)
+        {
+            Process(Generator.Generate(expression));
+        }
+
+        public void Process(Expressions.DeleteDefaultConstraintExpression expression)
+        {
+            Process(Generator.Generate(expression));
+        }
+
+        public bool SchemaExists(string schemaName)
+        {
+            throw new NotImplementedException("Method is not supported by the connectionless processor");
+        }
+
+        public bool TableExists(string schemaName, string tableName)
+        {
+            throw new NotImplementedException("Method is not supported by the connectionless processor");
+        }
+
+        public bool ColumnExists(string schemaName, string tableName, string columnName)
+        {
+            throw new NotImplementedException("Method is not supported by the connectionless processor");
+        }
+
+        public bool ConstraintExists(string schemaName, string tableName, string constraintName)
+        {
+            throw new NotImplementedException("Method is not supported by the connectionless processor");
+        }
+
+        public bool IndexExists(string schemaName, string tableName, string indexName)
+        {
+            throw new NotImplementedException("Method is not supported by the connectionless processor");
+        }
+
+        public bool SequenceExists(string schemaName, string sequenceName)
+        {
+            throw new NotImplementedException("Method is not supported by the connectionless processor");
+        }
+
+        public bool DefaultValueExists(string schemaName, string tableName, string columnName, object defaultValue)
+        {
+            throw new NotImplementedException("Method is not supported by the connectionless processor");
+        }
+
+        public string DatabaseType
+        {
+            get { return Context.Database; }
+        }
+
+        public void Dispose()
+        {
+            
+        }
+    }
+}


### PR DESCRIPTION
I'm interested in thoughts and feedback on the following scenario and migration runner changes. 

__Scenario__
In one of our current build scenarios we are required to provide our operations team SQL migration scripts for deployment into our production environment but because of security considerations we are not allowed to connect to the production database server nor are we allowed to run database migrations from within our code.

Because of this we required the ability to generated migrations SQL scripts for a given version range without connecting to a database.

__Proposed Changes__
This pull request adds two options to the IRunnerContext that will allow us to run migrations without a connection to a target database:

New Options:
* startVersion: the version number to start generating migrations from 
* noConnection: indicates that we want to run the migration without a connection string.

_Running a connectionless migration_

    Migrate.exe
    --version 0 --startVersion 2  --output --preview --task rollback -db SqlServer2012 --noConnection 
    --assembly   C:\Code\MigrationScripts.dll
    
To accomplish this we added a new ConnectionLessVersionLoader and ConnectionlessProcessor.  The rest of the included changes are simply used to load these classes when required.

__ConnectionLessVersionLoader__
Instead of querying the version info table for applied migrations like the current VersionLoader this class loads all the available migrations in the target assembly and loads the applied migrations with any migration less than the supplied 'startVersion' parameter

__ConnectionlessProcessor__
Instead of executing SQL against a database connection this processor simply emits the generated SQL to the Announcer.


    