### PR TITLE
Added ability to set Transaction Behavior and use Tags with MaintenanceAttribute

### DIFF
--- a/src/FluentMigrator.Runner/IMaintenanceLoader.cs
+++ b/src/FluentMigrator.Runner/IMaintenanceLoader.cs
@@ -16,10 +16,13 @@
 //
 #endregion
 
+using System.Collections.Generic;
+using FluentMigrator.Infrastructure;
+
 namespace FluentMigrator.Runner
 {
     public interface IMaintenanceLoader
     {
-        void ApplyMaintenance(MigrationStage stage);
+        IList<IMigrationInfo> LoadMaintenance(MigrationStage stage);
     }
 }

--- a/src/FluentMigrator.Runner/MaintenanceLoader.cs
+++ b/src/FluentMigrator.Runner/MaintenanceLoader.cs
@@ -19,21 +19,24 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using FluentMigrator.Infrastructure;
+using FluentMigrator.Infrastructure.Extensions;
 
 namespace FluentMigrator.Runner
 {
     public class MaintenanceLoader : IMaintenanceLoader
     {
-        private readonly IMigrationRunner _runner;
         private readonly IDictionary<MigrationStage, IList<IMigration>> _maintenance;
 
-        public MaintenanceLoader(IMigrationRunner runner, IMigrationConventions conventions)
+        public MaintenanceLoader(Assembly migrationAssembly, IEnumerable<string> tags, IMigrationConventions conventions)
         {
-            _runner = runner;
+            tags = tags ?? new string[] {};
             _maintenance = (
-                from type in runner.MigrationAssembly.GetExportedTypes()
+                from type in migrationAssembly.GetExportedTypes()
                 let stage = conventions.GetMaintenanceStage(type)
                 where stage != null
+                where conventions.TypeHasMatchingTags(type, tags)
                 let migration = (IMigration)Activator.CreateInstance(type)
                 group migration by stage
             ).ToDictionary(
@@ -41,17 +44,21 @@ namespace FluentMigrator.Runner
                 g => (IList<IMigration>)g.OrderBy(m => m.GetType().Name).ToArray()
             );
         }
-        
-        public void ApplyMaintenance(MigrationStage stage)
+
+        public IList<IMigrationInfo> LoadMaintenance(MigrationStage stage)
         {
             IList<IMigration> migrations;
+            IList<IMigrationInfo> migrationInfos = new List<IMigrationInfo>();
             if (!_maintenance.TryGetValue(stage, out migrations))
-                return;
+                return migrationInfos;
 
             foreach (var migration in migrations)
             {
-                _runner.Up(migration);
+                var transasctionBehavior = migration.GetType().GetOneAttribute<MaintenanceAttribute>().TransactionBehavior;
+                migrationInfos.Add(new NonAttributedMigrationToMigrationInfoAdapter(migration, transasctionBehavior));
             }
+
+            return migrationInfos;
         }
     }
 }

--- a/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -443,6 +443,7 @@
     <Compile Include="Unit\MigrationInfoTests.cs" />
     <Compile Include="Unit\MigrationRunnerTests.cs" />
     <Compile Include="Unit\ProfileLoaderTests.cs" />
+    <Compile Include="Unit\Runners\MaintenanceLoaderTests.cs" />
     <Compile Include="Unit\Runners\MigrationProcessorFactoryProviderTests.cs" />
     <Compile Include="Unit\Runners\Migrations\1_User.cs" />
     <Compile Include="Unit\Runners\Migrations\2_UserEmail.cs" />

--- a/src/FluentMigrator.Tests/Unit/DefaultMigrationConventionsTests.cs
+++ b/src/FluentMigrator.Tests/Unit/DefaultMigrationConventionsTests.cs
@@ -111,6 +111,13 @@ namespace FluentMigrator.Tests.Unit
         }
 
         [Test]
+        public void GetMaintenanceStageReturnsCorrectStage()
+        {
+            DefaultMigrationConventions.GetMaintenanceStage(typeof (MaintenanceAfterEach))
+                .ShouldBe(MigrationStage.AfterEach);
+        }
+
+        [Test]
         public void MigrationInfoShouldRetainMigration()
         {
             var migrationType = typeof(DefaultConventionMigrationFake);
@@ -273,6 +280,7 @@ namespace FluentMigrator.Tests.Unit
         }
     }
 
+
     [Tags("BE", "UK", "Staging", "Production")]
     public class TaggedWithBeAndUkAndProductionAndStagingInOneTagsAttribute
     {
@@ -311,4 +319,12 @@ namespace FluentMigrator.Tests.Unit
         public override void Up() { }
         public override void Down() { }
     }
+
+    [Maintenance(MigrationStage.AfterEach)]
+    internal class MaintenanceAfterEach : Migration
+    {
+        public override void Up() { }
+        public override void Down() { }
+    }
+
 }

--- a/src/FluentMigrator.Tests/Unit/Runners/MaintenanceLoaderTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Runners/MaintenanceLoaderTests.cs
@@ -1,0 +1,141 @@
+﻿#region License
+// 
+// Copyright (c) 2007-2009, Sean Chambers <schambers80@gmail.com>
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+using FluentMigrator.Infrastructure;
+using FluentMigrator.Infrastructure.Extensions;
+using FluentMigrator.Runner;
+using Moq;
+using NUnit.Framework;
+using NUnit.Should;
+
+namespace FluentMigrator.Tests.Unit.Runners
+{
+    [TestFixture]
+    public class MaintenanceLoaderTests
+    {
+        public const string Tag1 = "MaintenanceTestTag1";
+        public const string Tag2 = "MaintenanceTestTag2";
+        private string[] _tags = {Tag1, Tag2};
+
+        private Mock<IMigrationConventions> _migrationConventions;
+        private MaintenanceLoader _maintenanceLoader;
+
+        [SetUp]
+        public void Setup()
+        {
+            _migrationConventions = new Mock<IMigrationConventions>();
+            _migrationConventions.Setup(x => x.GetMaintenanceStage).Returns(DefaultMigrationConventions.GetMaintenanceStage);
+            _migrationConventions.Setup(x => x.TypeHasMatchingTags).Returns(DefaultMigrationConventions.TypeHasMatchingTags);
+
+            _maintenanceLoader = new MaintenanceLoader(this.GetType().Assembly, _tags, _migrationConventions.Object);
+        }
+
+        [Test]
+        public void LoadsMigrationsForCorrectStage()
+        {
+            var migrationInfos = _maintenanceLoader.LoadMaintenance(MigrationStage.BeforeEach);
+            _migrationConventions.Verify(x => x.GetMaintenanceStage, Times.AtLeastOnce());
+            Assert.IsNotEmpty(migrationInfos);
+
+            foreach (var migrationInfo in migrationInfos)
+            {
+                migrationInfo.Migration.ShouldNotBeNull();
+
+                var maintenanceAttribute = migrationInfo.Migration.GetType().GetOneAttribute<MaintenanceAttribute>();
+                maintenanceAttribute.ShouldNotBeNull();
+                maintenanceAttribute.Stage.ShouldBe(MigrationStage.BeforeEach);
+            }
+        }
+
+        [Test]
+        public void LoadsMigrationsFilteredByTag()
+        {
+            var migrationInfos = _maintenanceLoader.LoadMaintenance(MigrationStage.BeforeEach);
+            _migrationConventions.Verify(x => x.TypeHasMatchingTags, Times.AtLeastOnce());
+            Assert.IsNotEmpty(migrationInfos);
+
+            foreach (var migrationInfo in migrationInfos)
+            {
+                migrationInfo.Migration.ShouldNotBeNull();
+                DefaultMigrationConventions.TypeHasMatchingTags(migrationInfo.Migration.GetType(), _tags)
+                    .ShouldBeTrue();
+            } 
+        }
+
+        [Test]
+        public void MigrationInfoIsAttributedIsFalse()
+        {
+            var migrationInfos = _maintenanceLoader.LoadMaintenance(MigrationStage.BeforeEach);
+            Assert.IsNotEmpty(migrationInfos);
+
+            foreach (var migrationInfo in migrationInfos)
+            {
+                migrationInfo.IsAttributed().ShouldBeFalse();
+            }
+        }
+
+        [Test]
+        public void SetsTransactionBehaviorToSameAsMaintenanceAttribute()
+        {
+            var migrationInfos = _maintenanceLoader.LoadMaintenance(MigrationStage.BeforeEach);
+            Assert.IsNotEmpty(migrationInfos);
+
+            foreach (var migrationInfo in migrationInfos)
+            {
+                migrationInfo.Migration.ShouldNotBeNull();
+
+                var maintenanceAttribute = migrationInfo.Migration.GetType().GetOneAttribute<MaintenanceAttribute>();
+                maintenanceAttribute.ShouldNotBeNull();
+                migrationInfo.TransactionBehavior.ShouldBe(maintenanceAttribute.TransactionBehavior);
+            } 
+        }
+    }
+
+    [Tags(MaintenanceLoaderTests.Tag1, MaintenanceLoaderTests.Tag2)]
+    [Maintenance(MigrationStage.BeforeEach)]
+    public class MaintenanceBeforeEach : Migration
+    {
+        public override void Up() { }
+        public override void Down() { }
+    }
+
+    [Tags(MaintenanceLoaderTests.Tag1)]
+    [Tags(MaintenanceLoaderTests.Tag2)]
+    [Maintenance(MigrationStage.BeforeEach, TransactionBehavior.None)]
+    public class MaintenanceBeforeEachWithNonTransactionBehavior : Migration
+    {
+        public override void Up() { }
+        public override void Down() { }
+    }
+
+    [Tags("NonSpecifiedMaintenanceTestTag1")]
+    [Maintenance(MigrationStage.BeforeEach)]
+    public class MaintenanceBeforeEachWithoutTestTag : Migration
+    {
+        public override void Up() { }
+        public override void Down() { }
+    }
+
+    [Tags(MaintenanceLoaderTests.Tag1)]
+    [Maintenance(MigrationStage.AfterAll, TransactionBehavior.None)]
+    public class MaintenanceAfterAllWithNoneTransactionBehavior : Migration
+    {
+        public override void Up() { }
+        public override void Down() { }
+    }
+}

--- a/src/FluentMigrator/Infrastructure/NonAttributedMigrationToMigrationInfoAdapter.cs
+++ b/src/FluentMigrator/Infrastructure/NonAttributedMigrationToMigrationInfoAdapter.cs
@@ -24,10 +24,14 @@ namespace FluentMigrator.Infrastructure
     /// </summary>
     public class NonAttributedMigrationToMigrationInfoAdapter : IMigrationInfo
     {
-        public NonAttributedMigrationToMigrationInfoAdapter(IMigration migration)
+        public NonAttributedMigrationToMigrationInfoAdapter(IMigration migration) : this(migration, TransactionBehavior.Default)
+        {}
+
+        public NonAttributedMigrationToMigrationInfoAdapter(IMigration migration, TransactionBehavior transactionBehavior)
         {
-            if (migration == null) throw new ArgumentNullException("migration");
+             if (migration == null) throw new ArgumentNullException("migration");
             Migration = migration;
+            TransactionBehavior = transactionBehavior;
         }
 
         public string Description { get; private set; }
@@ -37,10 +41,7 @@ namespace FluentMigrator.Infrastructure
             get { return -1; }
         }
 
-        public TransactionBehavior TransactionBehavior
-        {
-            get { return TransactionBehavior.Default; }
-        }
+        public TransactionBehavior TransactionBehavior { get; private set;}
 
         public IMigration Migration { get; private set; }
 

--- a/src/FluentMigrator/MaintenanceAttribute.cs
+++ b/src/FluentMigrator/MaintenanceAttribute.cs
@@ -26,16 +26,24 @@ namespace FluentMigrator
     /// <remarks>
     /// Migration annotated with <see cref="MaintenanceAttribute" /> will be always executed
     /// when migrating the database to the latest version. The execution stage in which it would 
-    /// be executed is defined by <see cref="Stage" />.
+    /// be executed is defined by <see cref="Stage" />. The transaction behavior can also be defined
+    /// with the <see cref="TransactionBehavior"/>, which if not specified defaults to the default 
+    /// transaction behavior.
     /// </remarks>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
     public class MaintenanceAttribute : Attribute 
     {
         public MigrationStage Stage { get; private set; }
+        public TransactionBehavior TransactionBehavior { get; private set; }
 
-        public MaintenanceAttribute(MigrationStage stage)
+        public MaintenanceAttribute(MigrationStage stage) : this(stage, TransactionBehavior.Default)
+        {
+        }
+
+        public MaintenanceAttribute(MigrationStage stage, TransactionBehavior transactionBehavior)
         {
             this.Stage = stage;
+            this.TransactionBehavior = transactionBehavior;
         }
     }
 }


### PR DESCRIPTION
Added the ability to set the TransactionBehavior for a maintenance migration and added the ability to Tag a maintenance migration. I needed this functionality because as part of our QA database migration, we wanted to load the majority of the database from a backup and this has to be done outside of a transaction with SQL Server.

I added unit test for all the added functionality and some of the existing maintenance functionality. The code has also been tested in our QA database migrations.