### PR TITLE
Allows to specify custom version table meta data

### DIFF
--- a/src/FluentMigrator.Runner/IMigrationRunner.cs
+++ b/src/FluentMigrator.Runner/IMigrationRunner.cs
@@ -1,11 +1,14 @@
 using System.Reflection;
 
+using FluentMigrator.VersionTableInfo;
+
 namespace FluentMigrator.Runner
 {
     public interface IMigrationRunner : IMigrationScopeStarter
     {
         IMigrationProcessor Processor { get; }
         Assembly MigrationAssembly { get; }
+        IVersionTableMetaData CustomVersionTableMetaData { get; }
         void Up(IMigration migration);
         void Down(IMigration migration);
         void MigrateUp();

--- a/src/FluentMigrator.Runner/Initialization/IRunnerContext.cs
+++ b/src/FluentMigrator.Runner/Initialization/IRunnerContext.cs
@@ -18,6 +18,8 @@
 
 using System.Collections.Generic;
 
+using FluentMigrator.VersionTableInfo;
+
 namespace FluentMigrator.Runner.Initialization
 {
     public interface IRunnerContext
@@ -41,6 +43,16 @@ namespace FluentMigrator.Runner.Initialization
         string ProviderSwitches { get; set; }
 
         bool TransactionPerSession { get; set; }
+
+        /// <summary>
+        /// Gets or sets a custom version table meta data object.
+        /// </summary>
+        /// <remarks>
+        /// When this property is set its value will be used to get meta data about version table.
+        /// Use it to override default behavior of FluentMigrator to
+        /// search for a class having the VersionTableMetaData attribute.
+        /// </remarks>
+        IVersionTableMetaData VersionTableMetaData { get; set; }
 
         /// <summary>The arbitrary application context passed to the task runner.</summary>
         object ApplicationContext { get; set; }

--- a/src/FluentMigrator.Runner/Initialization/RunnerContext.cs
+++ b/src/FluentMigrator.Runner/Initialization/RunnerContext.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 
+using FluentMigrator.VersionTableInfo;
+
 namespace FluentMigrator.Runner.Initialization
 {
     public class RunnerContext : IRunnerContext
@@ -26,6 +28,16 @@ namespace FluentMigrator.Runner.Initialization
         public IEnumerable<string> Tags { get; set; }
         public bool TransactionPerSession { get; set; }
         public string ProviderSwitches { get; set; }
+
+        /// <summary>
+        /// Gets or sets a custom version table meta data object.
+        /// </summary>
+        /// <remarks>
+        /// When this property is set its value will be used to get meta data about version table.
+        /// Use it to override default behavior of FluentMigrator to
+        /// search for a class having the VersionTableMetaData attribute.
+        /// </remarks>
+        public IVersionTableMetaData VersionTableMetaData { get; set; }
 
         public IAnnouncer Announcer
         {

--- a/src/FluentMigrator.Runner/MigrationRunner.cs
+++ b/src/FluentMigrator.Runner/MigrationRunner.cs
@@ -28,6 +28,7 @@ using FluentMigrator.Runner.Initialization;
 using FluentMigrator.Runner.Processors;
 using FluentMigrator.Runner.Versioning;
 using FluentMigrator.Infrastructure.Extensions;
+using FluentMigrator.VersionTableInfo;
 
 namespace FluentMigrator.Runner
 {
@@ -53,6 +54,7 @@ namespace FluentMigrator.Runner
         public IMaintenanceLoader MaintenanceLoader { get; set; }
         public IMigrationConventions Conventions { get; private set; }
         public IList<Exception> CaughtExceptions { get; private set; }
+        public IVersionTableMetaData CustomVersionTableMetaData { get; private set; }
 
         public IMigrationScope CurrentScope
         {
@@ -74,6 +76,7 @@ namespace FluentMigrator.Runner
             _stopWatch = runnerContext.StopWatch;
             ApplicationContext = runnerContext.ApplicationContext;
             TransactionPerSession = runnerContext.TransactionPerSession;
+            CustomVersionTableMetaData = runnerContext.VersionTableMetaData;
 
             SilentlyFail = false;
             CaughtExceptions = null;

--- a/src/FluentMigrator.Runner/VersionLoader.cs
+++ b/src/FluentMigrator.Runner/VersionLoader.cs
@@ -54,12 +54,15 @@ namespace FluentMigrator.Runner
             dataExpression.Rows.Add(CreateVersionInfoInsertionData(version, description));
             dataExpression.TableName = VersionTableMetaData.TableName;
             dataExpression.SchemaName = VersionTableMetaData.SchemaName;
-            
+
             dataExpression.ExecuteWith(Processor);
         }
 
         public IVersionTableMetaData GetVersionTableMetaData()
         {
+            if (Runner.CustomVersionTableMetaData != null)
+                return Runner.CustomVersionTableMetaData;
+
             Type matchedType = Assembly.GetExportedTypes().FirstOrDefault(t => Conventions.TypeIsVersionTableMetaData(t));
 
             if (matchedType == null)


### PR DESCRIPTION
Introduction
------------
I have a PostgreSQL database with many independent schemas where all schemas have similar database structure and new schemas can be created on the fly.
Since I am already using FluentMigrator in the project and have excellent experience with it I tried to use it to populate schemas but, unfortunately, it failed.

The problem and solution
-----------
In this scenario every schema can be interpreted as an independent database. Each schema should have its own `VersionInfo` table, so I can run FluentMigrator for every schema and get expected result. For PostgreSQL this can be achieved very easily by setting SearchPath in the connection string ("...;SearchPath=schema1") and all migrations should now be applied to this schema only (and `VersionInfo` table will be created there too).
Unfortunately the PostgreSQL backend has strange behavior to use "public" as the default replacement for unspecified schema names, it makes this scenario impossible.

I can solve this on the migrations level by setting `ApplicationContext` to a schema name and using it everywhere where a schema name is expected, e.g. `Create.Table("test").InSchema((string)ApplicationContext)`. But there is no workaround for `VersionInfo` table, one can specify only static name for it via an object implementing `IVersionTableMetaData` interface which can only be instantiated from the assembly.

This patch allows to specify custom `IVersionTableMetaData` object via `IRunnerContext`. If the custom object is not set then old behavior is used (search for a class in the assembly).
