### PR TITLE
#612 Update Oracle TypeMap

### DIFF
--- a/src/FluentMigrator.Runner/Generators/Base/TypeMapBase.cs
+++ b/src/FluentMigrator.Runner/Generators/Base/TypeMapBase.cs
@@ -4,7 +4,7 @@ using System.Data;
 
 namespace FluentMigrator.Runner.Generators.Base
 {
-    internal abstract class TypeMapBase : ITypeMap
+    public abstract class TypeMapBase : ITypeMap
     {
         private readonly Dictionary<DbType, SortedList<int, string>> _templates = new Dictionary<DbType, SortedList<int, string>>();
         private const string SizePlaceholder = "$size";

--- a/src/FluentMigrator.Runner/Generators/Oracle/OracleTypeMap.cs
+++ b/src/FluentMigrator.Runner/Generators/Oracle/OracleTypeMap.cs
@@ -21,19 +21,19 @@ using FluentMigrator.Runner.Generators.Base;
 
 namespace FluentMigrator.Runner.Generators.Oracle
 {
-    internal class OracleTypeMap : TypeMapBase
+    public class OracleTypeMap : TypeMapBase
     {
         // See https://docs.oracle.com/cd/B28359_01/server.111/b28320/limits001.htm#i287903 
         // and http://docs.oracle.com/cd/B19306_01/server.102/b14220/datatype.htm#i13446
         // for limits in Oracle data types. 
-        public const int CharStringCapacity = 2000;    
         public const int AnsiStringCapacity = 4000;
         public const int AnsiTextCapacity = int.MaxValue;
-        public const int UnicodeStringCapacity = 4000;
-        public const int RawCapacity = 2000;
-        public const int UnicodeTextCapacity = int.MaxValue;
         public const int BlobCapacity = int.MaxValue;
+        public const int CharStringCapacity = 2000;
         public const int DecimalCapacity = 38;
+        public const int RawCapacity = 2000;
+        public const int UnicodeStringCapacity = 4000;
+        public const int UnicodeTextCapacity = int.MaxValue;
         
         protected override void SetupTypeMaps()
         {
@@ -43,8 +43,8 @@ namespace FluentMigrator.Runner.Generators.Oracle
             SetTypeMap(DbType.AnsiString, "VARCHAR2($size CHAR)", AnsiStringCapacity);
             SetTypeMap(DbType.AnsiString, "CLOB", AnsiTextCapacity);
             SetTypeMap(DbType.Binary, "RAW(2000)");
-            SetTypeMap(DbType.Binary, "RAW($size)", RawCapacity);
-            SetTypeMap(DbType.Binary, "RAW(MAX)", AnsiTextCapacity);
+            SetTypeMap(DbType.Binary, "RAW($size)", RawCapacity-1);
+            SetTypeMap(DbType.Binary, "RAW(MAX)", RawCapacity);
             SetTypeMap(DbType.Binary, "BLOB", BlobCapacity);
             SetTypeMap(DbType.Boolean, "NUMBER(1,0)");
             SetTypeMap(DbType.Byte, "NUMBER(3,0)");

--- a/src/FluentMigrator.Runner/Generators/Oracle/OracleTypeMap.cs
+++ b/src/FluentMigrator.Runner/Generators/Oracle/OracleTypeMap.cs
@@ -23,23 +23,27 @@ namespace FluentMigrator.Runner.Generators.Oracle
 {
     internal class OracleTypeMap : TypeMapBase
     {
-        public const int AnsiStringCapacity = 2000;
-        public const int AnsiTextCapacity = 2147483647;
-        public const int UnicodeStringCapacity = 2000;
+        // See https://docs.oracle.com/cd/B28359_01/server.111/b28320/limits001.htm#i287903 
+        // and http://docs.oracle.com/cd/B19306_01/server.102/b14220/datatype.htm#i13446
+        // for limits in Oracle data types. 
+        public const int CharStringCapacity = 2000;    
+        public const int AnsiStringCapacity = 4000;
+        public const int AnsiTextCapacity = int.MaxValue;
+        public const int UnicodeStringCapacity = 4000;
+        public const int RawCapacity = 2000;
         public const int UnicodeTextCapacity = int.MaxValue;
-        public const int BlobCapacity = 2147483647;
+        public const int BlobCapacity = int.MaxValue;
         public const int DecimalCapacity = 38;
-        public const int XmlCapacity = 1073741823;
-
+        
         protected override void SetupTypeMaps()
         {
             SetTypeMap(DbType.AnsiStringFixedLength, "CHAR(255 CHAR)");
-            SetTypeMap(DbType.AnsiStringFixedLength, "CHAR($size CHAR)", AnsiStringCapacity);
+            SetTypeMap(DbType.AnsiStringFixedLength, "CHAR($size CHAR)", CharStringCapacity);
             SetTypeMap(DbType.AnsiString, "VARCHAR2(255 CHAR)");
             SetTypeMap(DbType.AnsiString, "VARCHAR2($size CHAR)", AnsiStringCapacity);
             SetTypeMap(DbType.AnsiString, "CLOB", AnsiTextCapacity);
             SetTypeMap(DbType.Binary, "RAW(2000)");
-            SetTypeMap(DbType.Binary, "RAW($size)", AnsiStringCapacity);
+            SetTypeMap(DbType.Binary, "RAW($size)", RawCapacity);
             SetTypeMap(DbType.Binary, "RAW(MAX)", AnsiTextCapacity);
             SetTypeMap(DbType.Binary, "BLOB", BlobCapacity);
             SetTypeMap(DbType.Boolean, "NUMBER(1,0)");
@@ -56,7 +60,7 @@ namespace FluentMigrator.Runner.Generators.Oracle
             SetTypeMap(DbType.Int64, "NUMBER(19,0)");
             SetTypeMap(DbType.Single, "FLOAT(24)");
             SetTypeMap(DbType.StringFixedLength, "NCHAR(255)");
-            SetTypeMap(DbType.StringFixedLength, "NCHAR($size)", UnicodeStringCapacity);
+            SetTypeMap(DbType.StringFixedLength, "NCHAR($size)", CharStringCapacity);
             SetTypeMap(DbType.String, "NVARCHAR2(255)");
             SetTypeMap(DbType.String, "NVARCHAR2($size)", UnicodeStringCapacity);
             SetTypeMap(DbType.String, "NCLOB", UnicodeTextCapacity);

--- a/src/FluentMigrator.Runner/Generators/Oracle/OracleTypeMap.cs
+++ b/src/FluentMigrator.Runner/Generators/Oracle/OracleTypeMap.cs
@@ -43,8 +43,7 @@ namespace FluentMigrator.Runner.Generators.Oracle
             SetTypeMap(DbType.AnsiString, "VARCHAR2($size CHAR)", AnsiStringCapacity);
             SetTypeMap(DbType.AnsiString, "CLOB", AnsiTextCapacity);
             SetTypeMap(DbType.Binary, "RAW(2000)");
-            SetTypeMap(DbType.Binary, "RAW($size)", RawCapacity-1);
-            SetTypeMap(DbType.Binary, "RAW(MAX)", RawCapacity);
+            SetTypeMap(DbType.Binary, "RAW($size)", RawCapacity);
             SetTypeMap(DbType.Binary, "BLOB", BlobCapacity);
             SetTypeMap(DbType.Boolean, "NUMBER(1,0)");
             SetTypeMap(DbType.Byte, "NUMBER(3,0)");

--- a/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -423,6 +423,7 @@
     <Compile Include="Unit\Generators\Oracle\OracleSchemaTests.cs" />
     <Compile Include="Unit\Generators\Oracle\OracleSequenceTests.cs" />
     <Compile Include="Unit\Generators\Oracle\OracleTableTests.cs" />
+    <Compile Include="Unit\Generators\Oracle\OracleTypeMapTests.cs" />
     <Compile Include="Unit\Generators\Postgres\PostgresColumnTests.cs" />
     <Compile Include="Unit\Generators\Postgres\PostgresConstraintsTests.cs" />
     <Compile Include="Unit\Generators\Postgres\PostgresDataTests.cs" />

--- a/src/FluentMigrator.Tests/Unit/Generators/Oracle/OracleTypeMapTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/Oracle/OracleTypeMapTests.cs
@@ -1,0 +1,245 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using FluentMigrator.Runner.Generators;
+using FluentMigrator.Runner.Generators.Oracle;
+using NUnit.Framework;
+using NUnit.Should;
+
+namespace FluentMigrator.Tests.Unit.Generators.Oracle
+{
+    [TestFixture]
+    public class OracleTypeMapTests
+    {
+        private OracleTypeMap _typeMap;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _typeMap = new OracleTypeMap();
+        }
+
+        // See https://docs.oracle.com/cd/B28359_01/server.111/b28320/limits001.htm#i287903 
+        // and http://docs.oracle.com/cd/B19306_01/server.102/b14220/datatype.htm#i13446
+        // for limits in Oracle data types. 
+        [Test]
+        public void AnsiStringCapacityIs4000()
+        {
+            OracleTypeMap.AnsiStringCapacity.ShouldBe(4000);
+        }
+
+        [Test]
+        public void AnsiTextCapacityIsIntMaxValue()
+        {
+            OracleTypeMap.AnsiTextCapacity.ShouldBe(int.MaxValue);
+        }
+
+        [Test]
+        public void BlobCapacityIsIntMaxValue()
+        {
+            OracleTypeMap.BlobCapacity.ShouldBe(int.MaxValue);
+        }
+
+        [Test]
+        public void CharStringCapacityIs2000()
+        {
+            OracleTypeMap.CharStringCapacity.ShouldBe(2000);
+        }
+
+        [Test]
+        public void DecimalCapacityIs38()
+        {
+            OracleTypeMap.DecimalCapacity.ShouldBe(38);
+        }
+
+        [Test]
+        public void RawCapacityIs2000()
+        {
+            OracleTypeMap.RawCapacity.ShouldBe(2000);
+        }
+
+        [Test]
+        public void UnicodeStringCapacityIs4000()
+        {
+            OracleTypeMap.UnicodeStringCapacity.ShouldBe(4000);
+        }
+
+        [Test]
+        public void UnicodeTextCapacityIsIntMaxValue()
+        {
+            OracleTypeMap.UnicodeTextCapacity.ShouldBe(int.MaxValue);
+        }
+
+        [Test]
+        public void AnsiStringDefaultIsVarchar2_255()
+        {
+            _typeMap.GetTypeMap(DbType.AnsiString, 0, 0).ShouldBe("VARCHAR2(255 CHAR)");
+        }
+        
+        [Test]
+        public void AnsiStringOfSizeIsVarchar2OfSize()
+        {
+            _typeMap.GetTypeMap(DbType.AnsiString, 4000, 0).ShouldBe("VARCHAR2(4000 CHAR)");
+        }
+
+        [Test]
+        public void AnsiStringOver4000IsClob()
+        {
+            _typeMap.GetTypeMap(DbType.AnsiString, 4001, 0).ShouldBe("CLOB");
+        }
+
+        [Test]
+        public void AnsiStringFixedDefaultIsChar_255()
+        {
+            _typeMap.GetTypeMap(DbType.AnsiStringFixedLength, 0, 0).ShouldBe("CHAR(255 CHAR)");
+        }
+
+        [Test]
+        public void AnsiStringFixedOfSizeIsCharOfSize()
+        {
+            _typeMap.GetTypeMap(DbType.AnsiStringFixedLength, 2000, 0).ShouldBe("CHAR(2000 CHAR)");
+        }
+
+
+        [Test]
+        public void BinaryDefaultIsRaw_2000()
+        {
+            _typeMap.GetTypeMap(DbType.Binary, 0, 0).ShouldBe("RAW(2000)");
+        }
+
+        [Test]
+        public void BinaryOfSizeIsRawOfSize()
+        {
+            _typeMap.GetTypeMap(DbType.Binary, 1999, 0).ShouldBe("RAW(1999)");
+        }
+
+        [Test]
+        public void Binary2000IsRawMax()
+        {
+            _typeMap.GetTypeMap(DbType.Binary, 2000, 0).ShouldBe("RAW(MAX)");
+        }
+
+        [Test]
+        public void BinaryOver2000IsBlob()
+        {
+            _typeMap.GetTypeMap(DbType.Binary, 2001, 0).ShouldBe("BLOB");
+        }
+
+        [Test]
+        public void BooleanIsNumber()
+        {
+            _typeMap.GetTypeMap(DbType.Boolean, 0, 0).ShouldBe("NUMBER(1,0)");
+        }
+
+        [Test]
+        public void ByteIsNumber()
+        {
+            _typeMap.GetTypeMap(DbType.Byte, 0, 0).ShouldBe("NUMBER(3,0)");
+        }
+
+        [Test]
+        public void CurrencyIsNumber()
+        {
+            _typeMap.GetTypeMap(DbType.Currency, 0, 0).ShouldBe("NUMBER(19,1)");
+        }
+
+        [Test]
+        public void DateIsDate()
+        {
+            _typeMap.GetTypeMap(DbType.Date, 0, 0).ShouldBe("DATE");
+        }
+
+        [Test]
+        public void DateTimeIsTimestamp()
+        {
+            _typeMap.GetTypeMap(DbType.DateTime, 0, 0).ShouldBe("TIMESTAMP(4)");
+        }
+
+        [Test]
+        public void DecimalDefaultIsNumber()
+        {
+            _typeMap.GetTypeMap(DbType.Decimal, 0, 0).ShouldBe("NUMBER(19,5)");
+        }
+
+        [Test]
+        public void DecimalOfPrecisionIsNumberWithPrecision()
+        {
+            _typeMap.GetTypeMap(DbType.Decimal, 8, 3).ShouldBe("NUMBER(8,3)");
+        }
+
+        [Test]
+        public void DoubleIsDouble()
+        {
+            _typeMap.GetTypeMap(DbType.Double, 0, 0).ShouldBe("DOUBLE PRECISION");
+        }
+
+        [Test]
+        public void GuidIsRaw()
+        {
+            _typeMap.GetTypeMap(DbType.Guid, 0, 0).ShouldBe("RAW(16)");
+        }
+
+        [Test]
+        public void Int16IsNumber()
+        {
+            _typeMap.GetTypeMap(DbType.Int16, 0, 0).ShouldBe("NUMBER(5,0)");
+        }
+
+        [Test]
+        public void In32IsNumber()
+        {
+            _typeMap.GetTypeMap(DbType.Int32, 0, 0).ShouldBe("NUMBER(10,0)");
+        }
+
+        [Test]
+        public void Int64IsNumber()
+        {
+            _typeMap.GetTypeMap(DbType.Int64, 0, 0).ShouldBe("NUMBER(19,0)");
+        }
+
+        [Test]
+        public void SingleIsFloat()
+        {
+            _typeMap.GetTypeMap(DbType.Single, 0, 0).ShouldBe("FLOAT(24)");
+        }
+
+        [Test]
+        public void StringFixedLengthDefaultIsNChar_255()
+        {
+            _typeMap.GetTypeMap(DbType.StringFixedLength, 0, 0).ShouldBe("NCHAR(255)");
+        }
+
+        [Test]
+        public void StringFixedLengthOfSizeIsNCharOfSize()
+        {
+            _typeMap.GetTypeMap(DbType.StringFixedLength, 2000, 0).ShouldBe("NCHAR(2000)");
+        }
+
+
+        [Test]
+        public void StringDefaultIsNVarchar2_255()
+        {
+            _typeMap.GetTypeMap(DbType.String, 0, 0).ShouldBe("NVARCHAR2(255)");
+        }
+
+        [Test]
+        public void StringOfLengthIsNVarchar2fLength()
+        {
+            _typeMap.GetTypeMap(DbType.String, 4000, 0).ShouldBe("NVARCHAR2(4000)");
+        }
+
+        [Test]
+        public void TimeIsDate()
+        {
+            _typeMap.GetTypeMap(DbType.Time, 0, 0).ShouldBe("DATE");
+        }
+
+        [Test]
+        public void XmlIsXmltype()
+        {
+            _typeMap.GetTypeMap(DbType.Xml, 0, 0).ShouldBe("XMLTYPE");
+        }
+    }
+}

--- a/src/FluentMigrator.Tests/Unit/Generators/Oracle/OracleTypeMapTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/Oracle/OracleTypeMapTests.cs
@@ -25,54 +25,6 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
         // and http://docs.oracle.com/cd/B19306_01/server.102/b14220/datatype.htm#i13446
         // for limits in Oracle data types. 
         [Test]
-        public void AnsiStringCapacityIs4000()
-        {
-            OracleTypeMap.AnsiStringCapacity.ShouldBe(4000);
-        }
-
-        [Test]
-        public void AnsiTextCapacityIsIntMaxValue()
-        {
-            OracleTypeMap.AnsiTextCapacity.ShouldBe(int.MaxValue);
-        }
-
-        [Test]
-        public void BlobCapacityIsIntMaxValue()
-        {
-            OracleTypeMap.BlobCapacity.ShouldBe(int.MaxValue);
-        }
-
-        [Test]
-        public void CharStringCapacityIs2000()
-        {
-            OracleTypeMap.CharStringCapacity.ShouldBe(2000);
-        }
-
-        [Test]
-        public void DecimalCapacityIs38()
-        {
-            OracleTypeMap.DecimalCapacity.ShouldBe(38);
-        }
-
-        [Test]
-        public void RawCapacityIs2000()
-        {
-            OracleTypeMap.RawCapacity.ShouldBe(2000);
-        }
-
-        [Test]
-        public void UnicodeStringCapacityIs4000()
-        {
-            OracleTypeMap.UnicodeStringCapacity.ShouldBe(4000);
-        }
-
-        [Test]
-        public void UnicodeTextCapacityIsIntMaxValue()
-        {
-            OracleTypeMap.UnicodeTextCapacity.ShouldBe(int.MaxValue);
-        }
-
-        [Test]
         public void AnsiStringDefaultIsVarchar2_255()
         {
             _typeMap.GetTypeMap(DbType.AnsiString, 0, 0).ShouldBe("VARCHAR2(255 CHAR)");
@@ -112,14 +64,9 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
         [Test]
         public void BinaryOfSizeIsRawOfSize()
         {
-            _typeMap.GetTypeMap(DbType.Binary, 1999, 0).ShouldBe("RAW(1999)");
+            _typeMap.GetTypeMap(DbType.Binary, 2000, 0).ShouldBe("RAW(2000)");
         }
 
-        [Test]
-        public void Binary2000IsRawMax()
-        {
-            _typeMap.GetTypeMap(DbType.Binary, 2000, 0).ShouldBe("RAW(MAX)");
-        }
 
         [Test]
         public void BinaryOver2000IsBlob()


### PR DESCRIPTION
Updated Oracle typemap as per Oracle documentation:
https://docs.oracle.com/cd/B28359_01/server.111/b28320/limits001.htm#i287903 

CHAR  - max 2000
NCHAR - max 2000
VARCHAR2 - max 4000
NVARCHAR2 - max 4000
RAW     - max 2000