### PR TITLE
Corrected SqlServer2000 typemap (closes #571)

### DIFF
--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2000TypeMap.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2000TypeMap.cs
@@ -3,8 +3,7 @@ using FluentMigrator.Runner.Generators.Base;
 
 namespace FluentMigrator.Runner.Generators.SqlServer
 {
-
-    internal class SqlServer2000TypeMap : TypeMapBase
+    public class SqlServer2000TypeMap : TypeMapBase
     {
         public const int AnsiStringCapacity = 8000;
         public const int AnsiTextCapacity = 2147483647;
@@ -22,7 +21,6 @@ namespace FluentMigrator.Runner.Generators.SqlServer
             SetTypeMap(DbType.AnsiString, "TEXT", AnsiTextCapacity);
             SetTypeMap(DbType.Binary, "VARBINARY(8000)");
             SetTypeMap(DbType.Binary, "VARBINARY($size)", AnsiStringCapacity);
-            SetTypeMap(DbType.Binary, "VARBINARY(MAX)", int.MaxValue);
             SetTypeMap(DbType.Binary, "IMAGE", ImageCapacity);
             SetTypeMap(DbType.Boolean, "BIT");
             SetTypeMap(DbType.Byte, "TINYINT");
@@ -41,10 +39,9 @@ namespace FluentMigrator.Runner.Generators.SqlServer
             SetTypeMap(DbType.StringFixedLength, "NCHAR($size)", UnicodeStringCapacity);
             SetTypeMap(DbType.String, "NVARCHAR(255)");
             SetTypeMap(DbType.String, "NVARCHAR($size)", UnicodeStringCapacity);
-            SetTypeMap(DbType.String, "NVARCHAR(MAX)", int.MaxValue);
-            SetTypeMap(DbType.String, "NTEXT", UnicodeTextCapacity);
+            // Officially this is 1073741823 but we will allow the int.MaxValue Convention
+            SetTypeMap(DbType.String, "NTEXT", int.MaxValue);
             SetTypeMap(DbType.Time, "DATETIME");
-            SetTypeMap(DbType.Xml, "XML");
         }
     }
 }

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2005TypeMap.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2005TypeMap.cs
@@ -2,16 +2,18 @@
 
 namespace FluentMigrator.Runner.Generators.SqlServer
 {
-    internal class SqlServer2005TypeMap : SqlServer2000TypeMap
+    public class SqlServer2005TypeMap : SqlServer2000TypeMap
     {
         protected override void SetupTypeMaps()
         {
             base.SetupTypeMaps();
 
-            SetTypeMap(DbType.String, "NVARCHAR(MAX)", UnicodeTextCapacity);
+            // Officially this is 1073741823 but we will allow the int.MaxValue Convention
+            SetTypeMap(DbType.String, "NVARCHAR(MAX)", int.MaxValue);
             SetTypeMap(DbType.AnsiString, "VARCHAR(MAX)", AnsiTextCapacity);
             SetTypeMap(DbType.Binary, "VARBINARY(MAX)", ImageCapacity);
 
+            SetTypeMap(DbType.Xml, "XML");
         }
     }
 }

--- a/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -449,6 +449,8 @@
     <Compile Include="Unit\Generators\SqlServer2000\SqlServer2000IndexTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2000\SqlServer2000SchemaTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2000\SqlServer2000TableTests.cs" />
+    <Compile Include="Unit\Generators\SqlServer2000\SqlServer2000TypeMapTests.cs" />
+    <Compile Include="Unit\Generators\SqlServer2005\SqlServer2005TypeMapTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2005\SqlServer2005ClusteredTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2005\SqlServer2005ColumnTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2005\SqlServer2005ConstraintsTests.cs" />

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2000/SqlServer2000GeneratorTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2000/SqlServer2000GeneratorTests.cs
@@ -120,19 +120,6 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2000
         }
 
         [Test]
-        public void CanCreateXmlColumn()
-        {
-            var expression = new CreateColumnExpression
-                {
-                    TableName = "Table1",
-                    Column = new ColumnDefinition {Name = "MyXmlColumn", Type = DbType.Xml}
-                };
-
-            var result = Generator.Generate(expression);
-            result.ShouldNotBeNull();
-        }
-
-        [Test]
         public void CanDropSchemaInStrictMode()
         {
             Generator.compatabilityMode = Runner.CompatabilityMode.STRICT;

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2000/SqlServer2000TypeMapTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2000/SqlServer2000TypeMapTests.cs
@@ -1,0 +1,320 @@
+﻿using System;
+using System.Data;
+using FluentMigrator.Runner.Generators.SqlServer;
+using NUnit.Framework;
+using Shouldly;
+
+namespace FluentMigrator.Tests.Unit.Generators.SqlServer2000
+{
+    [TestFixture]
+    public abstract class SqlServer2000TypeMapTests
+    {
+        protected SqlServer2000TypeMap TypeMap { get; private set; }
+
+        [SetUp]
+        public void Setup()
+        {
+            TypeMap = new SqlServer2000TypeMap();
+        }
+
+        [TestFixture]
+        public class AnsistringTests : SqlServer2000TypeMapTests
+        {
+            [Test]
+            public void it_maps_ansistring_by_default_to_varchar_255()
+            {
+                var template = TypeMap.GetTypeMap(DbType.AnsiString, 0, 0);
+
+                template.ShouldBe("VARCHAR(255)");
+            }
+
+            [Test]
+            [TestCase(1)]
+            [TestCase(4000)]
+            [TestCase(8000)]
+            public void it_maps_ansistring_with_size_to_varchar_of_size(int size)
+            {
+                var template = TypeMap.GetTypeMap(DbType.AnsiString, size, 0);
+
+                template.ShouldBe(string.Format("VARCHAR({0})", size));
+            }
+
+            [Test]
+            [TestCase(8001)]
+            [TestCase(2147483647)]
+            public void it_maps_ansistring_with_size_above_8000_to_text(int size)
+            {
+                var template = TypeMap.GetTypeMap(DbType.AnsiString, size, 0);
+
+                template.ShouldBe("TEXT");
+            }
+        }
+
+        [TestFixture]
+        public class AnsistringFixedLengthTests : SqlServer2000TypeMapTests
+        {
+            [Test]
+            public void it_maps_ansistring_fixed_length_by_default_to_char_255()
+            {
+                var template = TypeMap.GetTypeMap(DbType.AnsiStringFixedLength, 0, 0);
+
+                template.ShouldBe("CHAR(255)");
+            }
+
+            [Test]
+            [TestCase(1)]
+            [TestCase(4000)]
+            [TestCase(8000)]
+            public void it_maps_ansistring_fixed_length_with_size_to_char_of_size(int size)
+            {
+                var template = TypeMap.GetTypeMap(DbType.AnsiStringFixedLength, size, 0);
+
+                template.ShouldBe(string.Format("CHAR({0})", size));
+            }
+
+            [Test]
+            public void it_throws_if_ansistring_fixed_length_has_size_above_8000()
+            {
+                Should.Throw<NotSupportedException>(
+                    () => TypeMap.GetTypeMap(DbType.AnsiStringFixedLength, 8001, 0));
+            }
+        }
+
+        [TestFixture]
+        public class StringTests : SqlServer2000TypeMapTests
+        {
+            [Test]
+            public void it_maps_string_by_default_to_nvarchar_255()
+            {
+                var template = TypeMap.GetTypeMap(DbType.String, 0, 0);
+
+                template.ShouldBe("NVARCHAR(255)");
+            }
+
+            [Test]
+            [TestCase(1)]
+            [TestCase(4000)]
+            public void it_maps_string_with_size_to_nvarchar_of_size(int size)
+            {
+                var template = TypeMap.GetTypeMap(DbType.String, size, 0);
+
+                template.ShouldBe(string.Format("NVARCHAR({0})", size));
+            }
+
+            [Test]
+            [TestCase(4001)]
+            [TestCase(1073741823)]
+            public void it_maps_string_with_size_above_4000_to_ntext(int size)
+            {
+                var template = TypeMap.GetTypeMap(DbType.String, size, 0);
+
+                template.ShouldBe("NTEXT");
+            }
+
+            [Test]
+            public void it_maps_string_with_size_above_1073741823_to_ntext_to_allow_int_maxvalue_convention()
+            {
+                var template = TypeMap.GetTypeMap(DbType.String, int.MaxValue, 0);
+
+                template.ShouldBe("NTEXT");
+            }
+        }
+
+        [TestFixture]
+        public class StringFixedLengthTests : SqlServer2000TypeMapTests
+        {
+            [Test]
+            public void it_maps_string_fixed_length_by_default_to_nchar_255()
+            {
+                var template = TypeMap.GetTypeMap(DbType.StringFixedLength, 0, 0);
+
+                template.ShouldBe("NCHAR(255)");
+            }
+
+
+            [Test]
+            [TestCase(1)]
+            [TestCase(4000)]
+            public void it_maps_string_fixed_length_with_size_to_nchar_of_size(int size)
+            {
+                var template = TypeMap.GetTypeMap(DbType.StringFixedLength, size, 0);
+
+                template.ShouldBe(string.Format("NCHAR({0})", size));
+            }
+
+            [Test]
+            public void it_throws_if_string_fixed_length_has_size_above_4000()
+            {
+                Should.Throw<NotSupportedException>(
+                    () => TypeMap.GetTypeMap(DbType.StringFixedLength, 4001, 0));
+            }
+        }
+
+        [TestFixture]
+        public class BinaryTests : SqlServer2000TypeMapTests
+        {
+            [Test]
+            public void it_maps_binary_by_default_to_varbinary_8000()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Binary, 0, 0);
+
+                template.ShouldBe("VARBINARY(8000)");
+            }
+
+            [Test]
+            [TestCase(1)]
+            [TestCase(4000)]
+            [TestCase(8000)]
+            public void it_maps_binary_with_size_to_varbinary_of_size(int size)
+            {
+                var template = TypeMap.GetTypeMap(DbType.Binary, size, 0);
+
+                template.ShouldBe(string.Format("VARBINARY({0})", size));
+            }
+
+            [Test]
+            [TestCase(8001)]
+            [TestCase(int.MaxValue)]
+            public void it_maps_binary_with_size_above_8000_to_image(int size)
+            {
+                var template = TypeMap.GetTypeMap(DbType.Binary, size, 0);
+
+                template.ShouldBe("IMAGE");
+            }
+        }
+
+        [TestFixture]
+        public class NumericTests : SqlServer2000TypeMapTests
+        {
+            [Test]
+            public void it_maps_boolean_to_bit()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Boolean, 0, 0);
+
+                template.ShouldBe("BIT");
+            }
+
+            [Test]
+            public void it_maps_byte_to_tinyint()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Byte, 0, 0);
+
+                template.ShouldBe("TINYINT");
+            }
+
+            [Test]
+            public void it_maps_int16_to_smallint()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Int16, 0, 0);
+
+                template.ShouldBe("SMALLINT");
+            }
+
+            [Test]
+            public void it_maps_int32_to_int()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Int32, 0, 0);
+
+                template.ShouldBe("INT");
+            }
+
+            [Test]
+            public void it_maps_int64_to_bigint()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Int64, 0, 0);
+
+                template.ShouldBe("BIGINT");
+            }
+
+            [Test]
+            public void it_maps_single_to_real()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Single, 0, 0);
+
+                template.ShouldBe("REAL");
+            }
+
+            [Test]
+            public void it_maps_double_to_double_precision()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Double, 0, 0);
+
+                template.ShouldBe("DOUBLE PRECISION");
+            }
+
+            [Test]
+            public void it_maps_currency_to_money()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Currency, 0, 0);
+
+                template.ShouldBe("MONEY");
+            }
+
+            [Test]
+            public void it_maps_decimal_by_default_to_decimal_19_5()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Decimal, 0, 0);
+
+                template.ShouldBe("DECIMAL(19,5)");
+            }
+
+            [Test]
+            [TestCase(1)]
+            [TestCase(20)]
+            [TestCase(38)]
+            public void it_maps_decimal_with_precision_to_decimal(int precision)
+            {
+                var template = TypeMap.GetTypeMap(DbType.Decimal, precision, 1);
+
+                template.ShouldBe(string.Format("DECIMAL({0},1)", precision));
+            }
+
+            [Test]
+            public void it_throws_if_decimal_precision_is_above_38()
+            {
+                Should.Throw<NotSupportedException>(
+                    () => TypeMap.GetTypeMap(DbType.Decimal, 39, 0));
+            }
+        }
+
+        [TestFixture]
+        public class GuidTests : SqlServer2000TypeMapTests
+        {
+            [Test]
+            public void it_maps_guid_to_uniqueidentifier()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Guid, 0, 0);
+
+                template.ShouldBe("UNIQUEIDENTIFIER");
+            }
+        }
+
+        [TestFixture]
+        public class DateTimeTests : SqlServer2000TypeMapTests
+        {
+            [Test]
+            public void it_maps_time_to_datetime()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Time, 0, 0);
+
+                template.ShouldBe("DATETIME");
+            }
+
+            [Test]
+            public void it_maps_date_to_datetime()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Date, 0, 0);
+
+                template.ShouldBe("DATETIME");
+            }
+
+            [Test]
+            public void it_maps_datetime_to_datetime()
+            {
+                var template = TypeMap.GetTypeMap(DbType.DateTime, 0, 0);
+
+                template.ShouldBe("DATETIME");
+            }
+        }
+    }
+}

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005TypeMapTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005TypeMapTests.cs
@@ -1,0 +1,332 @@
+﻿using System;
+using System.Data;
+using FluentMigrator.Runner.Generators.SqlServer;
+using NUnit.Framework;
+using Shouldly;
+
+namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
+{
+    [TestFixture]
+    public abstract class SqlServer2005TypeMapTests
+    {
+        protected SqlServer2005TypeMap TypeMap { get; private set; }
+
+        [SetUp]
+        public void Setup()
+        {
+            TypeMap = new SqlServer2005TypeMap();
+        }
+
+        [TestFixture]
+        public class AnsistringTests : SqlServer2005TypeMapTests
+        {
+            [Test]
+            public void it_maps_ansistring_by_default_to_varchar_255()
+            {
+                var template = TypeMap.GetTypeMap(DbType.AnsiString, 0, 0);
+
+                template.ShouldBe("VARCHAR(255)");
+            }
+
+            [Test]
+            [TestCase(1)]
+            [TestCase(4000)]
+            [TestCase(8000)]
+            public void it_maps_ansistring_with_size_to_varchar_of_size(int size)
+            {
+                var template = TypeMap.GetTypeMap(DbType.AnsiString, size, 0);
+
+                template.ShouldBe(string.Format("VARCHAR({0})", size));
+            }
+
+            [Test]
+            [TestCase(8001)]
+            [TestCase(2147483647)]
+            public void it_maps_ansistring_with_size_above_8000_to_varchar_max(int size)
+            {
+                var template = TypeMap.GetTypeMap(DbType.AnsiString, size, 0);
+
+                template.ShouldBe("VARCHAR(MAX)");
+            }
+        }
+
+        [TestFixture]
+        public class AnsistringFixedLengthTests : SqlServer2005TypeMapTests
+        {
+            [Test]
+            public void it_maps_ansistring_fixed_length_by_default_to_char_255()
+            {
+                var template = TypeMap.GetTypeMap(DbType.AnsiStringFixedLength, 0, 0);
+
+                template.ShouldBe("CHAR(255)");
+            }
+
+            [Test]
+            [TestCase(1)]
+            [TestCase(4000)]
+            [TestCase(8000)]
+            public void it_maps_ansistring_fixed_length_with_size_to_char_of_size(int size)
+            {
+                var template = TypeMap.GetTypeMap(DbType.AnsiStringFixedLength, size, 0);
+
+                template.ShouldBe(string.Format("CHAR({0})", size));
+            }
+
+            [Test]
+            public void it_throws_if_ansistring_fixed_length_has_size_above_8000()
+            {
+                Should.Throw<NotSupportedException>(
+                    () => TypeMap.GetTypeMap(DbType.AnsiStringFixedLength, 8001, 0));
+            }
+        }
+
+        [TestFixture]
+        public class StringTests : SqlServer2005TypeMapTests
+        {
+            [Test]
+            public void it_maps_string_by_default_to_nvarchar_255()
+            {
+                var template = TypeMap.GetTypeMap(DbType.String, 0, 0);
+
+                template.ShouldBe("NVARCHAR(255)");
+            }
+
+            [Test]
+            [TestCase(1)]
+            [TestCase(4000)]
+            public void it_maps_string_with_size_to_nvarchar_of_size(int size)
+            {
+                var template = TypeMap.GetTypeMap(DbType.String, size, 0);
+
+                template.ShouldBe(string.Format("NVARCHAR({0})", size));
+            }
+
+            [Test]
+            [TestCase(4001)]
+            [TestCase(1073741823)]
+            public void it_maps_string_with_size_above_4000_to_nvarchar_max(int size)
+            {
+                var template = TypeMap.GetTypeMap(DbType.String, size, 0);
+
+                template.ShouldBe("NVARCHAR(MAX)");
+            }
+
+            [Test]
+            public void it_maps_string_with_size_above_1073741823_to_nvarchar_max_to_allow_int_maxvalue_convention()
+            {
+                var template = TypeMap.GetTypeMap(DbType.String, int.MaxValue, 0);
+
+                template.ShouldBe("NVARCHAR(MAX)");
+            }
+        }
+
+        [TestFixture]
+        public class StringFixedLengthTests : SqlServer2005TypeMapTests
+        {
+            [Test]
+            public void it_maps_string_fixed_length_by_default_to_nchar_255()
+            {
+                var template = TypeMap.GetTypeMap(DbType.StringFixedLength, 0, 0);
+
+                template.ShouldBe("NCHAR(255)");
+            }
+
+
+            [Test]
+            [TestCase(1)]
+            [TestCase(4000)]
+            public void it_maps_string_fixed_length_with_size_to_nchar_of_size(int size)
+            {
+                var template = TypeMap.GetTypeMap(DbType.StringFixedLength, size, 0);
+
+                template.ShouldBe(string.Format("NCHAR({0})", size));
+            }
+
+            [Test]
+            public void it_throws_if_string_fixed_length_has_size_above_4000()
+            {
+                Should.Throw<NotSupportedException>(
+                    () => TypeMap.GetTypeMap(DbType.StringFixedLength, 4001, 0));
+            }
+        }
+
+        [TestFixture]
+        public class BinaryTests : SqlServer2005TypeMapTests
+        {
+            [Test]
+            public void it_maps_binary_by_default_to_varbinary_8000()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Binary, 0, 0);
+
+                template.ShouldBe("VARBINARY(8000)");
+            }
+
+            [Test]
+            [TestCase(1)]
+            [TestCase(4000)]
+            [TestCase(8000)]
+            public void it_maps_binary_with_size_to_varbinary_of_size(int size)
+            {
+                var template = TypeMap.GetTypeMap(DbType.Binary, size, 0);
+
+                template.ShouldBe(string.Format("VARBINARY({0})", size));
+            }
+
+            [Test]
+            [TestCase(8001)]
+            [TestCase(int.MaxValue)]
+            public void it_maps_binary_with_size_above_8000_to_varbinary_max(int size)
+            {
+                var template = TypeMap.GetTypeMap(DbType.Binary, size, 0);
+
+                template.ShouldBe("VARBINARY(MAX)");
+            }
+        }
+
+        [TestFixture]
+        public class NumericTests : SqlServer2005TypeMapTests
+        {
+            [Test]
+            public void it_maps_boolean_to_bit()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Boolean, 0, 0);
+
+                template.ShouldBe("BIT");
+            }
+
+            [Test]
+            public void it_maps_byte_to_tinyint()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Byte, 0, 0);
+
+                template.ShouldBe("TINYINT");
+            }
+
+            [Test]
+            public void it_maps_int16_to_smallint()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Int16, 0, 0);
+
+                template.ShouldBe("SMALLINT");
+            }
+
+            [Test]
+            public void it_maps_int32_to_int()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Int32, 0, 0);
+
+                template.ShouldBe("INT");
+            }
+
+            [Test]
+            public void it_maps_int64_to_bigint()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Int64, 0, 0);
+
+                template.ShouldBe("BIGINT");
+            }
+
+            [Test]
+            public void it_maps_single_to_real()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Single, 0, 0);
+
+                template.ShouldBe("REAL");
+            }
+
+            [Test]
+            public void it_maps_double_to_double_precision()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Double, 0, 0);
+
+                template.ShouldBe("DOUBLE PRECISION");
+            }
+
+            [Test]
+            public void it_maps_currency_to_money()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Currency, 0, 0);
+
+                template.ShouldBe("MONEY");
+            }
+
+            [Test]
+            public void it_maps_decimal_by_default_to_decimal_19_5()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Decimal, 0, 0);
+
+                template.ShouldBe("DECIMAL(19,5)");
+            }
+
+            [Test]
+            [TestCase(1)]
+            [TestCase(20)]
+            [TestCase(38)]
+            public void it_maps_decimal_with_precision_to_decimal(int precision)
+            {
+                var template = TypeMap.GetTypeMap(DbType.Decimal, precision, 1);
+
+                template.ShouldBe(string.Format("DECIMAL({0},1)", precision));
+            }
+
+            [Test]
+            public void it_throws_if_decimal_precision_is_above_38()
+            {
+                Should.Throw<NotSupportedException>(
+                    () => TypeMap.GetTypeMap(DbType.Decimal, 39, 0));
+            }
+        }
+
+        [TestFixture]
+        public class GuidTests : SqlServer2005TypeMapTests
+        {
+            [Test]
+            public void it_maps_guid_to_uniqueidentifier()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Guid, 0, 0);
+
+                template.ShouldBe("UNIQUEIDENTIFIER");
+            }
+        }
+
+        [TestFixture]
+        public class DateTimeTests : SqlServer2005TypeMapTests
+        {
+            [Test]
+            public void it_maps_time_to_datetime()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Time, 0, 0);
+
+                template.ShouldBe("DATETIME");
+            }
+
+            [Test]
+            public void it_maps_date_to_datetime()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Date, 0, 0);
+
+                template.ShouldBe("DATETIME");
+            }
+
+            [Test]
+            public void it_maps_datetime_to_datetime()
+            {
+                var template = TypeMap.GetTypeMap(DbType.DateTime, 0, 0);
+
+                template.ShouldBe("DATETIME");
+            }
+        }
+
+        [TestFixture]
+        public class XmlTests : SqlServer2005TypeMapTests
+        {
+            [Test]
+            public void it_maps_xml_to_xml()
+            {
+                var template = TypeMap.GetTypeMap(DbType.Xml, 0, 0);
+
+                template.ShouldBe("XML");
+            }
+        }
+    }
+}


### PR DESCRIPTION
-  SqlServer2000 (AsString, AsAnsiString, AsBinary maps to
 NTEXT,TEXT,IMAGE)
- SqlServer2000 Removed xml mapping (supported from 2005)
- Allowing the AsString(int.maxvalue) convention
- Added tests for both sql2000 as well as 2005 type map