### PR TITLE
Datetimeoffset feature patch - not quoting the values appropriately

### DIFF
--- a/src/FluentMigrator.Runner/Generators/Generic/GenericQuoter.cs
+++ b/src/FluentMigrator.Runner/Generators/Generic/GenericQuoter.cs
@@ -23,6 +23,7 @@ namespace FluentMigrator.Runner.Generators.Generic
             if (value is bool) { return FormatBool((bool)value); }
             if (value is Guid) { return FormatGuid((Guid)value); }
             if (value is DateTime) { return FormatDateTime((DateTime)value); }
+            if (value is DateTimeOffset) { return FormatDateTimeOffset((DateTimeOffset)value); }
             if (value.GetType().IsEnum) { return FormatEnum(value); }
             if (value is double) {return FormatDouble((double)value);}
             if (value is float) {return FormatFloat((float)value);}
@@ -91,6 +92,11 @@ namespace FluentMigrator.Runner.Generators.Generic
         public virtual string FormatDateTime(DateTime value)
         {
             return ValueQuote + (value).ToString("yyyy-MM-ddTHH:mm:ss",CultureInfo.InvariantCulture) + ValueQuote;
+        }
+
+        public virtual string FormatDateTimeOffset(DateTimeOffset value) 
+        {
+            return ValueQuote + (value).ToString("yyyy-MM-ddTHH:mm:ss zzz", CultureInfo.InvariantCulture) + ValueQuote;
         }
 
         public virtual string FormatEnum(object value)

--- a/src/FluentMigrator.Tests/Unit/Generators/GenericGenerator/QuoterTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/GenericGenerator/QuoterTests.cs
@@ -143,6 +143,23 @@ namespace FluentMigrator.Tests.Unit.Generators
         }
 
         [Test]
+        public void DateTimeOffsetIsFormattedIso8601WithQuotes() 
+        {
+            ChangeCulture();
+            DateTimeOffset date = new DateTimeOffset(2010, 1, 2, 18, 4, 5, 123, TimeSpan.FromHours(-4));
+            quoter.QuoteValue(date).ShouldBe("'2010-01-02T18:04:05 -04:00'");
+        }
+
+        [Test]
+        public void DateTimeOffsetIsFormattedIso8601WithQuotes_WithItalyAsCulture() 
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("it-IT");
+            DateTimeOffset date = new DateTimeOffset(2010, 1, 2, 18, 4, 5, 123, TimeSpan.FromHours(-4));
+            quoter.QuoteValue(date)
+                .ShouldBe("'2010-01-02T18:04:05 -04:00'");
+        }
+
+        [Test]
         public void EnumIsFormattedAsString()
         {
             quoter.QuoteValue(Foo.Bar)


### PR DESCRIPTION
So, when i implemented the `DateTimeOffset` feature, i missed the idea of making sure that, when you created the insert/update scripts within a migration, that the `DateTimeOffset`s were quoted appropriately.

Pull Request is to correct this issue.