### PR TITLE
Update OracleTypeMap.cs

### DIFF
--- a/src/FluentMigrator.Runner/Generators/Oracle/OracleTypeMap.cs
+++ b/src/FluentMigrator.Runner/Generators/Oracle/OracleTypeMap.cs
@@ -47,7 +47,7 @@ namespace FluentMigrator.Runner.Generators.Oracle
             SetTypeMap(DbType.Binary, "BLOB", BlobCapacity);
             SetTypeMap(DbType.Boolean, "NUMBER(1,0)");
             SetTypeMap(DbType.Byte, "NUMBER(3,0)");
-            SetTypeMap(DbType.Currency, "NUMBER(19,1)");
+            SetTypeMap(DbType.Currency, "NUMBER(19,4)");
             SetTypeMap(DbType.Date, "DATE");
             SetTypeMap(DbType.DateTime, "TIMESTAMP(4)");
             SetTypeMap(DbType.Decimal, "NUMBER(19,5)");

--- a/src/FluentMigrator.Tests/Unit/Generators/Oracle/OracleTypeMapTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/Oracle/OracleTypeMapTests.cs
@@ -89,7 +89,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
         [Test]
         public void CurrencyIsNumber()
         {
-            _typeMap.GetTypeMap(DbType.Currency, 0, 0).ShouldBe("NUMBER(19,1)");
+            _typeMap.GetTypeMap(DbType.Currency, 0, 0).ShouldBe("NUMBER(19,4)");
         }
 
         [Test]


### PR DESCRIPTION
Bump precision to 4 places, matching Oracle's equivalent to SQL Server's MONEY data type.