### PR TITLE
Allow for types with no namespaces

### DIFF
--- a/src/FluentMigrator.Runner/TypeFinder.cs
+++ b/src/FluentMigrator.Runner/TypeFinder.cs
@@ -27,7 +27,7 @@ namespace FluentMigrator.Runner
                 if (loadNestedNamespaces)
                 {
                     string matchNested = @namespace + ".";
-                    shouldInclude = t => t.Namespace == @namespace || t.Namespace.StartsWith(matchNested);
+                    shouldInclude = t => t.Namespace != null && (t.Namespace == @namespace || t.Namespace.StartsWith(matchNested));
                 }
 
                 return types.Where(shouldInclude);


### PR DESCRIPTION
I am trying to upgrade to latest version and have a number of extension classes in the same assembly without namespaces, and with t.Namespace being null am getting the dreaded NullReferenceException.

This of course assumes that you put your Migrations in a Namespace.