### PR TITLE
Fix incorrect console argument in DisplayHelp

### DIFF
--- a/src/FluentMigrator.Console/MigratorConsole.cs
+++ b/src/FluentMigrator.Console/MigratorConsole.cs
@@ -252,7 +252,7 @@ namespace FluentMigrator.Console
             consoleAnnouncer.Write("             server=.\\SQLExpress;database=Foo;trusted_connection=true");
             consoleAnnouncer.Write("   ");
             consoleAnnouncer.Write("OR use a named connection string from the machine.config:");
-            consoleAnnouncer.Write("  migrate -a bin\\debug\\MyMigrations.dll -db SqlServer2008 -connectionName \"namedConnection\" -profile \"Debug\"");
+            consoleAnnouncer.Write("  migrate -a bin\\debug\\MyMigrations.dll -db SqlServer2008 -conn \"namedConnection\" -profile \"Debug\"");
             consoleAnnouncer.HorizontalRule();
             consoleAnnouncer.Write("Options:");
             p.WriteOptionDescriptions(System.Console.Out);


### PR DESCRIPTION
The `DisplayHelp` method incorrectly reported "connectionName" when it should have matched "connectionString=|connection=|conn=|c=" as it is defined in MigratorConsole.cs.

It now is "conn" to match the usage in `DisplayHelp` above.

Pretty minor, but it caused me a little confusion when I was referring to the command line help.