### PR TITLE
Feature/idempotent migrations

### DIFF
--- a/src/FluentMigrator.Runner/Generators/Generic/GenericGenerator.cs
+++ b/src/FluentMigrator.Runner/Generators/Generic/GenericGenerator.cs
@@ -33,6 +33,8 @@ namespace FluentMigrator.Runner.Generators.Generic
         public virtual string AlterSchema { get { return "ALTER SCHEMA {0} TRANSFER {1}.{2}"; } }
         public virtual string DropSchema { get { return "DROP SCHEMA {0}"; } }
 
+        public virtual string DropSchemaIdempotent { get { return "IF (EXISTS (SELECT * FROM sys.schemas WHERE name = '{0}')) BEGIN EXEC sp_executesql N'DROP SCHEMA [{0}]' END"; } }
+
         public virtual string CreateIndex { get { return "CREATE {0}{1}INDEX {2} ON {3} ({4})"; } }
         public virtual string DropIndex { get { return "DROP INDEX {0}"; } }
 

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2005Generator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2005Generator.cs
@@ -56,9 +56,9 @@ namespace FluentMigrator.Runner.Generators.SqlServer
         public override string DeleteData { get { return "DELETE FROM {0}.{1} WHERE {2}"; } }
         public override string IdentityInsert { get { return "SET IDENTITY_INSERT {0}.{1} {2}"; } }
 
-        public override string CreateForeignKeyConstraint { get { return "ALTER TABLE {0}.{1} ADD CONSTRAINT [{2}] FOREIGN KEY ({3}) REFERENCES {4}.{5} ({6}){7}{8}"; } }
+        public override string CreateForeignKeyConstraint { get { return "ALTER TABLE [{0}].{1} ADD CONSTRAINT [{2}] FOREIGN KEY ({3}) REFERENCES {4}.{5} ({6}){7}{8}"; } }
 
-        public string CreateForeignKeyConstraintIdempotent { get { return "IF (OBJECT_ID('{2}', 'F') IS NULL) BEGIN ALTER TABLE {0}.{1} ADD CONSTRAINT [{2}] FOREIGN KEY ({3}) REFERENCES {4}.{5} ({6}){7}{8} END"; } }
+        public string CreateForeignKeyConstraintIdempotent { get { return "IF (OBJECT_ID('{0}.{2}', 'F') IS NULL) BEGIN ALTER TABLE [{0}].{1} ADD CONSTRAINT [{2}] FOREIGN KEY ({3}) REFERENCES {4}.{5} ({6}){7}{8} END"; } }
         public override string CreateConstraint { get { return "{0} ADD CONSTRAINT {1} {2}{3} ({4})"; } }
         public override string DeleteConstraint { get { return "{0} DROP CONSTRAINT {1}"; } }
 
@@ -245,7 +245,7 @@ namespace FluentMigrator.Runner.Generators.SqlServer
             }
             return string.Format(
                 expression.CheckIfExists ? CreateForeignKeyConstraintIdempotent : CreateForeignKeyConstraint,
-                Quoter.QuoteSchemaName(expression.ForeignKey.ForeignTableSchema),
+                expression.ForeignKey.ForeignTableSchema,
                 Quoter.QuoteTableName(expression.ForeignKey.ForeignTable),
                 expression.ForeignKey.Name,
                 String.Join(", ", foreignColumns.ToArray()),

--- a/src/FluentMigrator.Runner/Versioning/VersionMigration.cs
+++ b/src/FluentMigrator.Runner/Versioning/VersionMigration.cs
@@ -55,7 +55,7 @@ namespace FluentMigrator.Runner.Versioning
         public override void Up()
         {
             if (!string.IsNullOrEmpty(_versionTableMetaData.SchemaName))
-                Create.Schema(_versionTableMetaData.SchemaName);
+                Create.Schema(_versionTableMetaData.SchemaName, false);
         }
 
         public override void Down()

--- a/src/FluentMigrator.Tests/Unit/Generators/GeneratorTestHelper.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/GeneratorTestHelper.cs
@@ -343,6 +343,12 @@ namespace FluentMigrator.Tests.Unit.Generators
             return new CreateColumnExpression { TableName = TestTableName1, Column = column };
         }
 
+        public static CreateColumnExpression GetCreateColumnExpressionIdempotent()
+        {
+            ColumnDefinition column = new ColumnDefinition { Name = TestColumnName1, Type = DbType.String, Size = 5 };
+            return new CreateColumnExpression { TableName = TestTableName1, Column = column, CheckIfExists = true };
+        }
+
         public static CreateColumnExpression GetCreateColumnExpressionWithDescription()
         {
             CreateColumnExpression columnExpression = GetCreateColumnExpression();
@@ -424,6 +430,18 @@ namespace FluentMigrator.Tests.Unit.Generators
         public static CreateForeignKeyExpression GetCreateForeignKeyExpression()
         {
             var expression = new CreateForeignKeyExpression();
+            expression.ForeignKey.PrimaryTable = TestTableName2;
+            expression.ForeignKey.ForeignTable = TestTableName1;
+            expression.ForeignKey.PrimaryColumns = new[] { TestColumnName2 };
+            expression.ForeignKey.ForeignColumns = new[] { TestColumnName1 };
+
+            expression.ApplyConventions(new MigrationConventions());
+            return expression;
+        }
+
+        public static CreateForeignKeyExpression GetCreateForeignKeyExpressionIdempotent()
+        {
+            var expression = new CreateForeignKeyExpression { CheckIfExists = true };
             expression.ForeignKey.PrimaryTable = TestTableName2;
             expression.ForeignKey.ForeignTable = TestTableName1;
             expression.ForeignKey.PrimaryColumns = new[] { TestColumnName2 };

--- a/src/FluentMigrator.Tests/Unit/Generators/GeneratorTestHelper.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/GeneratorTestHelper.cs
@@ -492,9 +492,23 @@ namespace FluentMigrator.Tests.Unit.Generators
             return new DeleteTableExpression { TableName = TestTableName1 };
         }
 
+        public static DeleteTableExpression GetDeleteTableExpressionIdempotent()
+        {
+            return new DeleteTableExpression { TableName = TestTableName1, CheckIfExists = true };
+        }
+
         public static DeleteColumnExpression GetDeleteColumnExpression()
         {
             return GetDeleteColumnExpression(new[] { TestColumnName1 });
+        }
+
+        public static DeleteColumnExpression GetDeleteColumnExpressionIdempotent()
+        {
+            var expression = GetDeleteColumnExpression(new[] { TestColumnName1 });
+            expression.CheckIfExists = true;
+            expression.SchemaName = "TestSchema";
+
+            return expression;
         }
 
         public static DeleteColumnExpression GetDeleteColumnExpression(string[] columns)
@@ -516,6 +530,15 @@ namespace FluentMigrator.Tests.Unit.Generators
             return expression;
         }
 
+        public static DeleteForeignKeyExpression GetDeleteForeignKeyExpressionIdempotent()
+        {
+            var expression = new DeleteForeignKeyExpression();
+            expression.ForeignKey.Name = "FK_Test";
+            expression.ForeignKey.ForeignTable = TestTableName1;
+            expression.CheckIfExists = true;
+            return expression;
+        }
+
         public static DeleteConstraintExpression GetDeletePrimaryKeyExpression()
         {
             var expression = new DeleteConstraintExpression(ConstraintType.PrimaryKey);
@@ -527,6 +550,11 @@ namespace FluentMigrator.Tests.Unit.Generators
         public static DeleteSchemaExpression GetDeleteSchemaExpression()
         {
             return new DeleteSchemaExpression { SchemaName = "TestSchema" };
+        }
+
+        public static DeleteSchemaExpression GetDeleteSchemaExpressionIdempotent()
+        {
+            return new DeleteSchemaExpression { SchemaName = "TestSchema", CheckIfExists = true };
         }
 
         public static DeleteSequenceExpression GetDeleteSequenceExpression()

--- a/src/FluentMigrator.Tests/Unit/Generators/GeneratorTestHelper.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/GeneratorTestHelper.cs
@@ -23,7 +23,15 @@ namespace FluentMigrator.Tests.Unit.Generators
 
         public static CreateTableExpression GetCreateTableExpression()
         {
-            CreateTableExpression expression = new CreateTableExpression() { TableName = TestTableName1, };
+            CreateTableExpression expression = new CreateTableExpression() { TableName = TestTableName1 };
+            expression.Columns.Add(new ColumnDefinition { Name = TestColumnName1, Type = DbType.String });
+            expression.Columns.Add(new ColumnDefinition { Name = TestColumnName2, Type = DbType.Int32 });
+            return expression;
+        }
+
+        public static CreateTableExpression GetCreateTableIdempotentExpression()
+        {
+            CreateTableExpression expression = new CreateTableExpression() { TableName = TestTableName1, CheckIfExists = true };
             expression.Columns.Add(new ColumnDefinition { Name = TestColumnName1, Type = DbType.String });
             expression.Columns.Add(new ColumnDefinition { Name = TestColumnName2, Type = DbType.Int32 });
             return expression;
@@ -126,6 +134,11 @@ namespace FluentMigrator.Tests.Unit.Generators
         public static CreateSchemaExpression GetCreateSchemaExpression()
         {
             return new CreateSchemaExpression { SchemaName = "TestSchema" };
+        }
+
+        public static CreateSchemaExpression GetCreateSchemaIfNotExistsExpression()
+        {
+            return new CreateSchemaExpression { SchemaName = "TestSchema", CheckIfExists = true};
         }
 
         public static CreateSequenceExpression GetCreateSequenceExpression()

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005ColumnTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005ColumnTests.cs
@@ -66,6 +66,16 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
         }
 
         [Test]
+        public void CanCreateColumnWithCustomSchemaIdempotent()
+        {
+            var expression = GeneratorTestHelper.GetCreateColumnExpressionIdempotent();
+            expression.SchemaName = "TestSchema";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("IF NOT EXISTS(SELECT * FROM sys.columns WHERE Name = N'TestColumn1' AND Object_ID = Object_ID(N'TestSchema.TestTable1')) BEGIN ALTER TABLE [TestSchema].[TestTable1] ADD [TestColumn1] NVARCHAR(5) NOT NULL END");
+        }
+
+        [Test]
         public override void CanCreateColumnWithDefaultSchema()
         {
             var expression = GeneratorTestHelper.GetCreateColumnExpression();

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005ConstraintsTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005ConstraintsTests.cs
@@ -197,6 +197,17 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
         }
 
         [Test]
+        public void CanCreateForeignKeyWithCustomSchemaIdempotent()
+        {
+            var expression = GeneratorTestHelper.GetCreateForeignKeyExpressionIdempotent();
+            expression.ForeignKey.ForeignTableSchema = "TestSchema";
+            expression.ForeignKey.PrimaryTableSchema = "TestSchema";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("IF (OBJECT_ID('FK_TestTable1_TestColumn1_TestTable2_TestColumn2', 'F') IS NULL) BEGIN ALTER TABLE [TestSchema].[TestTable1] ADD CONSTRAINT [FK_TestTable1_TestColumn1_TestTable2_TestColumn2] FOREIGN KEY ([TestColumn1]) REFERENCES [TestSchema].[TestTable2] ([TestColumn2]) END");
+        }
+
+        [Test]
         public override void CanCreateForeignKeyWithDefaultSchema()
         {
             var expression = GeneratorTestHelper.GetCreateForeignKeyExpression();

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005ConstraintsTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005ConstraintsTests.cs
@@ -509,6 +509,16 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
         }
 
         [Test]
+        public void CanDropForeignKeyWithCustomSchemaIdempotent()
+        {
+            var expression = GeneratorTestHelper.GetDeleteForeignKeyExpressionIdempotent();
+            expression.ForeignKey.ForeignTableSchema = "TestSchema";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("IF (OBJECT_ID('TestSchema.FK_Test', 'F') IS NOT NULL) BEGIN ALTER TABLE [TestSchema].[TestTable1] DROP CONSTRAINT [FK_Test] END");
+        }
+
+        [Test]
         public override void CanDropForeignKeyWithDefaultSchema()
         {
             var expression = GeneratorTestHelper.GetDeleteForeignKeyExpression();

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005ConstraintsTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005ConstraintsTests.cs
@@ -204,7 +204,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
             expression.ForeignKey.PrimaryTableSchema = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("IF (OBJECT_ID('FK_TestTable1_TestColumn1_TestTable2_TestColumn2', 'F') IS NULL) BEGIN ALTER TABLE [TestSchema].[TestTable1] ADD CONSTRAINT [FK_TestTable1_TestColumn1_TestTable2_TestColumn2] FOREIGN KEY ([TestColumn1]) REFERENCES [TestSchema].[TestTable2] ([TestColumn2]) END");
+            result.ShouldBe("IF (OBJECT_ID('TestSchema.FK_TestTable1_TestColumn1_TestTable2_TestColumn2', 'F') IS NULL) BEGIN ALTER TABLE [TestSchema].[TestTable1] ADD CONSTRAINT [FK_TestTable1_TestColumn1_TestTable2_TestColumn2] FOREIGN KEY ([TestColumn1]) REFERENCES [TestSchema].[TestTable2] ([TestColumn2]) END");
         }
 
         [Test]

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005SchemaTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005SchemaTests.cs
@@ -48,10 +48,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
             var expression = GeneratorTestHelper.GetCreateSchemaIfNotExistsExpression();
 
             var result = Generator.Generate(expression);
-            result.ShouldBe(@"IF (NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '[TestSchema]')) 
-                                    BEGIN
-                                        CREATE SCHEMA [TestSchema]
-                                    END");
+            result.ShouldBe(@"IF (NOT EXISTS (SELECT * FROM sys.schemas WHERE name = 'TestSchema')) BEGIN EXEC sp_executesql N'CREATE SCHEMA [TestSchema]' END");
         }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005SchemaTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005SchemaTests.cs
@@ -50,5 +50,14 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
             var result = Generator.Generate(expression);
             result.ShouldBe(@"IF (NOT EXISTS (SELECT * FROM sys.schemas WHERE name = 'TestSchema')) BEGIN EXEC sp_executesql N'CREATE SCHEMA [TestSchema]' END");
         }
+
+        [Test]
+        public void CanDropSchemaIdempotent()
+        {
+            var expression = GeneratorTestHelper.GetDeleteSchemaExpressionIdempotent();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("IF (EXISTS (SELECT * FROM sys.schemas WHERE name = 'TestSchema')) BEGIN EXEC sp_executesql N'DROP SCHEMA [TestSchema]' END");
+        }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005SchemaTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005SchemaTests.cs
@@ -41,5 +41,17 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
             var result = Generator.Generate(expression);
             result.ShouldBe("DROP SCHEMA [TestSchema]");
         }
+
+        [Test]
+        public void CanCreateSchemaIdempotent()
+        {
+            var expression = GeneratorTestHelper.GetCreateSchemaIfNotExistsExpression();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe(@"IF (NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '[TestSchema]')) 
+                                    BEGIN
+                                        CREATE SCHEMA [TestSchema]
+                                    END");
+        }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005TableTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005TableTests.cs
@@ -241,6 +241,16 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
         }
 
         [Test]
+        public void CanDropTableWithCustomSchemaIdempotent()
+        {
+            var expression = GeneratorTestHelper.GetDeleteTableExpressionIdempotent();
+            expression.SchemaName = "TestSchema";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("IF (EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'TestSchema' AND TABLE_NAME = 'TestTable1')) BEGIN DROP TABLE [TestSchema].[TestTable1] END");
+        }
+
+        [Test]
         public override void CanDropTableWithDefaultSchema()
         {
             var expression = GeneratorTestHelper.GetDeleteTableExpression();

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005TableTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005TableTests.cs
@@ -38,7 +38,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
             expression.Columns[1].CustomType = "[timestamp]";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("IF (EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '[TestSchema]' AND TABLE_NAME = '[TestTable1]')) BEGIN CREATE TABLE [TestSchema].[TestTable1] ([TestColumn1] NVARCHAR(255) NOT NULL, [TestColumn2] [timestamp] NOT NULL, PRIMARY KEY ([TestColumn1])) END");
+            result.ShouldBe("IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'TestSchema' AND TABLE_NAME = 'TestTable1')) BEGIN CREATE TABLE [TestSchema].[TestTable1] ([TestColumn1] NVARCHAR(255) NOT NULL, [TestColumn2] [timestamp] NOT NULL, PRIMARY KEY ([TestColumn1])) END");
         }
 
         [Test]

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005TableTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005TableTests.cs
@@ -29,6 +29,19 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
         }
 
         [Test]
+        public void CanCreateTableWithCustomColumnTypeWithCustomSchemaIdempotent()
+        {
+            var expression = GeneratorTestHelper.GetCreateTableIdempotentExpression();
+            expression.SchemaName = "TestSchema";
+            expression.Columns[0].IsPrimaryKey = true;
+            expression.Columns[1].Type = null;
+            expression.Columns[1].CustomType = "[timestamp]";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("IF (EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '[TestSchema]' AND TABLE_NAME = '[TestTable1]')) BEGIN CREATE TABLE [TestSchema].[TestTable1] ([TestColumn1] NVARCHAR(255) NOT NULL, [TestColumn2] [timestamp] NOT NULL, PRIMARY KEY ([TestColumn1])) END");
+        }
+
+        [Test]
         public override void CanCreateTableWithCustomColumnTypeWithDefaultSchema()
         {
             var expression = GeneratorTestHelper.GetCreateTableExpression();

--- a/src/FluentMigrator/Builders/Create/CreateExpressionRoot.cs
+++ b/src/FluentMigrator/Builders/Create/CreateExpressionRoot.cs
@@ -43,30 +43,30 @@ namespace FluentMigrator.Builders.Create
             _context.Expressions.Add(expression);
         }
 
-        public ICreateTableWithColumnOrSchemaOrDescriptionSyntax Table(string tableName)
+        public ICreateTableWithColumnOrSchemaOrDescriptionSyntax Table(string tableName, bool checkIfExists = false)
         {
-            var expression = new CreateTableExpression { TableName = tableName };
+            var expression = new CreateTableExpression { TableName = tableName, CheckIfExists = checkIfExists };
             _context.Expressions.Add(expression);
             return new CreateTableExpressionBuilder(expression, _context);
         }
 
-        public ICreateColumnOnTableSyntax Column(string columnName)
+        public ICreateColumnOnTableSyntax Column(string columnName, bool checkIfExists = false)
         {
-            var expression = new CreateColumnExpression { Column = { Name = columnName } };
+            var expression = new CreateColumnExpression { Column = { Name = columnName }, CheckIfExists = checkIfExists };
             _context.Expressions.Add(expression);
             return new CreateColumnExpressionBuilder(expression, _context);
         }
 
-        public ICreateForeignKeyFromTableSyntax ForeignKey()
+        public ICreateForeignKeyFromTableSyntax ForeignKey(bool checkIfExists = false)
         {
-            var expression = new CreateForeignKeyExpression();
+            var expression = new CreateForeignKeyExpression { CheckIfExists = checkIfExists };
             _context.Expressions.Add(expression);
             return new CreateForeignKeyExpressionBuilder(expression);
         }
 
-        public ICreateForeignKeyFromTableSyntax ForeignKey(string foreignKeyName)
+        public ICreateForeignKeyFromTableSyntax ForeignKey(string foreignKeyName, bool checkIfExists = false)
         {
-            var expression = new CreateForeignKeyExpression { ForeignKey = { Name = foreignKeyName } };
+            var expression = new CreateForeignKeyExpression { ForeignKey = { Name = foreignKeyName }, CheckIfExists = checkIfExists };
             _context.Expressions.Add(expression);
             return new CreateForeignKeyExpressionBuilder(expression);
         }

--- a/src/FluentMigrator/Builders/Create/CreateExpressionRoot.cs
+++ b/src/FluentMigrator/Builders/Create/CreateExpressionRoot.cs
@@ -37,9 +37,9 @@ namespace FluentMigrator.Builders.Create
             _context = context;
         }
 
-        public void Schema(string schemaName)
+        public void Schema(string schemaName, bool checkIfExists = false)
         {
-            var expression = new CreateSchemaExpression { SchemaName = schemaName };
+            var expression = new CreateSchemaExpression { SchemaName = schemaName, CheckIfExists = checkIfExists };
             _context.Expressions.Add(expression);
         }
 

--- a/src/FluentMigrator/Builders/Create/ICreateExpressionRoot.cs
+++ b/src/FluentMigrator/Builders/Create/ICreateExpressionRoot.cs
@@ -28,7 +28,7 @@ namespace FluentMigrator.Builders.Create
 {
     public interface ICreateExpressionRoot : IFluentSyntax
     {
-        void Schema(string schemaName);
+        void Schema(string schemaName, bool checkIfExists = false);
         ICreateTableWithColumnOrSchemaOrDescriptionSyntax Table(string tableName);
         ICreateColumnOnTableSyntax Column(string columnName);
         ICreateForeignKeyFromTableSyntax ForeignKey();

--- a/src/FluentMigrator/Builders/Create/ICreateExpressionRoot.cs
+++ b/src/FluentMigrator/Builders/Create/ICreateExpressionRoot.cs
@@ -29,10 +29,10 @@ namespace FluentMigrator.Builders.Create
     public interface ICreateExpressionRoot : IFluentSyntax
     {
         void Schema(string schemaName, bool checkIfExists = false);
-        ICreateTableWithColumnOrSchemaOrDescriptionSyntax Table(string tableName);
-        ICreateColumnOnTableSyntax Column(string columnName);
-        ICreateForeignKeyFromTableSyntax ForeignKey();
-        ICreateForeignKeyFromTableSyntax ForeignKey(string foreignKeyName);
+        ICreateTableWithColumnOrSchemaOrDescriptionSyntax Table(string tableName, bool checkIfExists = false);
+        ICreateColumnOnTableSyntax Column(string columnName, bool checkIfExists = false);
+        ICreateForeignKeyFromTableSyntax ForeignKey(bool checkIfExists = false);
+        ICreateForeignKeyFromTableSyntax ForeignKey(string foreignKeyName, bool checkIfExists = false);
         ICreateIndexForTableSyntax Index();
         ICreateIndexForTableSyntax Index(string indexName);
 

--- a/src/FluentMigrator/Builders/Create/Table/CreateTableExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Create/Table/CreateTableExpressionBuilder.cs
@@ -58,6 +58,12 @@ namespace FluentMigrator.Builders.Create.Table
             return this;
         }
 
+        public ICreateTableColumnAsTypeSyntax IfNotExists()
+        {
+            Expression.CheckIfExists = true;
+            return this;
+        }
+        
         public ICreateTableWithColumnOrSchemaSyntax WithDescription(string description)
         {
             Expression.TableDescription = description;

--- a/src/FluentMigrator/Builders/Delete/DeleteExpressionRoot.cs
+++ b/src/FluentMigrator/Builders/Delete/DeleteExpressionRoot.cs
@@ -38,36 +38,36 @@ namespace FluentMigrator.Builders.Delete
             _context = context;
         }
 
-        public void Schema(string schemaName)
+        public void Schema(string schemaName, bool checkIfExists = false)
         {
-            var expression = new DeleteSchemaExpression {SchemaName = schemaName};
+            var expression = new DeleteSchemaExpression {SchemaName = schemaName, CheckIfExists = checkIfExists };
             _context.Expressions.Add(expression);
         }
 
-        public IInSchemaSyntax Table(string tableName)
+        public IInSchemaSyntax Table(string tableName, bool checkIfExists = false)
         {
-            var expression = new DeleteTableExpression {TableName = tableName};
+            var expression = new DeleteTableExpression {TableName = tableName, CheckIfExists = checkIfExists};
             _context.Expressions.Add(expression);
             return new DeleteTableExpressionBuilder(expression);
         }
 
-        public IDeleteColumnFromTableSyntax Column(string columnName)
+        public IDeleteColumnFromTableSyntax Column(string columnName, bool checkIfExists = false)
         {
-            var expression = new DeleteColumnExpression {ColumnNames = {columnName}};
+            var expression = new DeleteColumnExpression {ColumnNames = {columnName}, CheckIfExists = checkIfExists};
             _context.Expressions.Add(expression);
             return new DeleteColumnExpressionBuilder(expression);
         }
 
-        public IDeleteForeignKeyFromTableSyntax ForeignKey()
+        public IDeleteForeignKeyFromTableSyntax ForeignKey(bool checkIfExists = false)
         {
-            var expression = new DeleteForeignKeyExpression();
+            var expression = new DeleteForeignKeyExpression { CheckIfExists = checkIfExists };
             _context.Expressions.Add(expression);
             return new DeleteForeignKeyExpressionBuilder(expression);
         }
 
-        public IDeleteForeignKeyOnTableSyntax ForeignKey(string foreignKeyName)
+        public IDeleteForeignKeyOnTableSyntax ForeignKey(string foreignKeyName, bool checkIfExists = false)
         {
-            var expression = new DeleteForeignKeyExpression {ForeignKey = {Name = foreignKeyName}};
+            var expression = new DeleteForeignKeyExpression {ForeignKey = {Name = foreignKeyName}, CheckIfExists = checkIfExists};
             _context.Expressions.Add(expression);
             return new DeleteForeignKeyExpressionBuilder(expression);
         }

--- a/src/FluentMigrator/Builders/Delete/IDeleteExpressionRoot.cs
+++ b/src/FluentMigrator/Builders/Delete/IDeleteExpressionRoot.cs
@@ -27,11 +27,11 @@ namespace FluentMigrator.Builders.Delete
 {
     public interface IDeleteExpressionRoot : IFluentSyntax
     {
-        void Schema(string schemaName);
-        IInSchemaSyntax Table(string tableName);
-        IDeleteColumnFromTableSyntax Column(string columnName);
-        IDeleteForeignKeyFromTableSyntax ForeignKey();
-        IDeleteForeignKeyOnTableSyntax ForeignKey(string foreignKeyName);
+        void Schema(string schemaName, bool checkIfExists = false);
+        IInSchemaSyntax Table(string tableName, bool checkIfExists = false);
+        IDeleteColumnFromTableSyntax Column(string columnName, bool checkIfExists = false);
+        IDeleteForeignKeyFromTableSyntax ForeignKey(bool checkIfExists = false);
+        IDeleteForeignKeyOnTableSyntax ForeignKey(string foreignKeyName, bool checkIfExists = false);
         IDeleteDataOrInSchemaSyntax FromTable(string tableName);
 
         /// <summary>

--- a/src/FluentMigrator/Expressions/CreateColumnExpression.cs
+++ b/src/FluentMigrator/Expressions/CreateColumnExpression.cs
@@ -28,6 +28,7 @@ namespace FluentMigrator.Expressions
         public virtual string SchemaName { get; set; }
         public virtual string TableName { get; set; }
         public virtual ColumnDefinition Column { get; set; }
+        public virtual bool CheckIfExists { get; set; }
 
         public CreateColumnExpression()
         {

--- a/src/FluentMigrator/Expressions/CreateForeignKeyExpression.cs
+++ b/src/FluentMigrator/Expressions/CreateForeignKeyExpression.cs
@@ -25,6 +25,7 @@ namespace FluentMigrator.Expressions
     public class CreateForeignKeyExpression : MigrationExpressionBase
     {
         public virtual ForeignKeyDefinition ForeignKey { get; set; }
+        public virtual bool CheckIfExists { get; set; }
 
         public CreateForeignKeyExpression()
         {

--- a/src/FluentMigrator/Expressions/CreateSchemaExpression.cs
+++ b/src/FluentMigrator/Expressions/CreateSchemaExpression.cs
@@ -8,6 +8,8 @@ namespace FluentMigrator.Expressions
     {
         public virtual string SchemaName { get; set; }
 
+        public virtual bool CheckIfExists { get; set; }
+
         public override void CollectValidationErrors(ICollection<string> errors)
         {
             if (String.IsNullOrEmpty(SchemaName))

--- a/src/FluentMigrator/Expressions/CreateTableExpression.cs
+++ b/src/FluentMigrator/Expressions/CreateTableExpression.cs
@@ -29,6 +29,7 @@ namespace FluentMigrator.Expressions
         public virtual string TableName { get; set; }
         public virtual IList<ColumnDefinition> Columns { get; set; }
         public virtual string TableDescription { get; set; }
+        public virtual bool CheckIfExists { get; set; }
 
         public CreateTableExpression()
         {

--- a/src/FluentMigrator/Expressions/DeleteColumnExpression.cs
+++ b/src/FluentMigrator/Expressions/DeleteColumnExpression.cs
@@ -33,6 +33,7 @@ namespace FluentMigrator.Expressions
         public virtual string SchemaName { get; set; }
         public virtual string TableName { get; set; }
         public ICollection<string> ColumnNames { get; set; }
+        public virtual bool CheckIfExists { get; set; }
 
         public override void CollectValidationErrors(ICollection<string> errors)
         {

--- a/src/FluentMigrator/Expressions/DeleteForeignKeyExpression.cs
+++ b/src/FluentMigrator/Expressions/DeleteForeignKeyExpression.cs
@@ -27,6 +27,7 @@ namespace FluentMigrator.Expressions
     public class DeleteForeignKeyExpression : MigrationExpressionBase
     {
         public virtual ForeignKeyDefinition ForeignKey { get; set; }
+        public virtual bool CheckIfExists { get; set; }
 
         public DeleteForeignKeyExpression()
         {

--- a/src/FluentMigrator/Expressions/DeleteSchemaExpression.cs
+++ b/src/FluentMigrator/Expressions/DeleteSchemaExpression.cs
@@ -26,6 +26,8 @@ namespace FluentMigrator.Expressions
     {
         public virtual string SchemaName { get; set; }
 
+        public virtual bool CheckIfExists { get; set; }
+
         public override void CollectValidationErrors(ICollection<string> errors)
         {
             if (String.IsNullOrEmpty(SchemaName))

--- a/src/FluentMigrator/Expressions/DeleteTableExpression.cs
+++ b/src/FluentMigrator/Expressions/DeleteTableExpression.cs
@@ -26,6 +26,7 @@ namespace FluentMigrator.Expressions
     {
         public virtual string SchemaName { get; set; }
         public virtual string TableName { get; set; }
+        public virtual bool CheckIfExists { get; set; }
 
         public override void CollectValidationErrors(ICollection<string> errors)
         {


### PR DESCRIPTION
There is one thing which FluentMigrator lacks in my opinion - idempotent migrations(or rather idempotent generated SQL output). This is the only thing which prevents me from using it on production environment in my work(we have to prepare SQL scripts for DBA team because we haven't been permission to perform automatic migrations yet).

Because it would be easier to use original package than the one from our private NuGet gallery, I would like to ask whether it would be possible to introduce those change into FM :)