### PR TITLE
Invalid syntax error if description contains quote

### DIFF
--- a/src/FluentMigrator.Runner/Generators/Oracle/OracleDescriptionGenerator.cs
+++ b/src/FluentMigrator.Runner/Generators/Oracle/OracleDescriptionGenerator.cs
@@ -26,7 +26,10 @@ namespace FluentMigrator.Runner.Generators.Oracle
             if (string.IsNullOrEmpty(tableDescription))
                 return string.Empty;
 
-            return string.Format(TableDescriptionTemplate, GetFullTableName(schemaName, tableName), tableDescription);
+            return string.Format(
+                TableDescriptionTemplate, 
+                GetFullTableName(schemaName, tableName), 
+                tableDescription.Replace("'", "''"));
         }
 
         protected override string GenerateColumnDescription(
@@ -39,7 +42,7 @@ namespace FluentMigrator.Runner.Generators.Oracle
                 ColumnDescriptionTemplate,
                 GetFullTableName(schemaName, tableName),
                 columnName,
-                columnDescription);
+                columnDescription.Replace("'", "''"));
         }
     }
 }

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2005DescriptionGenerator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2005DescriptionGenerator.cs
@@ -57,7 +57,7 @@ namespace FluentMigrator.Runner.Generators.SqlServer
             var formattedSchemaName = FormatSchemaName(schemaName);
 
             return string.Format(TableDescriptionTemplate,
-                tableDescription,
+                tableDescription.Replace("'", "''"),
                 formattedSchemaName,
                 tableName);
         }
@@ -69,7 +69,7 @@ namespace FluentMigrator.Runner.Generators.SqlServer
 
             var formattedSchemaName = FormatSchemaName(schemaName);
 
-            return string.Format(ColumnDescriptionTemplate, columnDescription, formattedSchemaName, tableName, columnName);
+            return string.Format(ColumnDescriptionTemplate, columnDescription.Replace("'", "''"), formattedSchemaName, tableName, columnName);
         }
 
         private string GenerateTableDescriptionRemoval(string schemaName, string tableName)


### PR DESCRIPTION
See PR https://github.com/logary/logary/pull/91

SqlServer description generator is not allowed to have quotes in column or table description.