### PR TITLE
Execute.Sql option to enable echoing command to output file

### DIFF
--- a/src/FluentMigrator.Runner/ConnectionlessVersionLoader.cs
+++ b/src/FluentMigrator.Runner/ConnectionlessVersionLoader.cs
@@ -134,7 +134,7 @@ namespace FluentMigrator.Runner
             return new InsertionDataDefinition
             {
                 new KeyValuePair<string, object>(VersionTableMetaData.ColumnName, version),
-                new KeyValuePair<string, object>(VersionTableMetaData.AppliedOnColumnName, DateTime.UtcNow),
+                new KeyValuePair<string, object>(VersionTableMetaData.AppliedOnColumnName, RawSql.Insert("GETDATE()")),
                 new KeyValuePair<string, object>(VersionTableMetaData.DescriptionColumnName, description)
             };
         }

--- a/src/FluentMigrator.Runner/ConnectionlessVersionLoader.cs
+++ b/src/FluentMigrator.Runner/ConnectionlessVersionLoader.cs
@@ -134,7 +134,7 @@ namespace FluentMigrator.Runner
             return new InsertionDataDefinition
             {
                 new KeyValuePair<string, object>(VersionTableMetaData.ColumnName, version),
-                new KeyValuePair<string, object>(VersionTableMetaData.AppliedOnColumnName, RawSql.Insert("GETDATE()")),
+                new KeyValuePair<string, object>(VersionTableMetaData.AppliedOnColumnName, RawSql.Insert("CURRENT_TIMESTAMP")),
                 new KeyValuePair<string, object>(VersionTableMetaData.DescriptionColumnName, description)
             };
         }

--- a/src/FluentMigrator.Runner/VersionLoader.cs
+++ b/src/FluentMigrator.Runner/VersionLoader.cs
@@ -61,7 +61,7 @@ namespace FluentMigrator.Runner
             dataExpression.Rows.Add(CreateVersionInfoInsertionData(version, description));
             dataExpression.TableName = VersionTableMetaData.TableName;
             dataExpression.SchemaName = VersionTableMetaData.SchemaName;
-            
+
             dataExpression.ExecuteWith(Processor);
         }
 
@@ -88,7 +88,7 @@ namespace FluentMigrator.Runner
             return new InsertionDataDefinition
                        {
                            new KeyValuePair<string, object>(VersionTableMetaData.ColumnName, version),
-                           new KeyValuePair<string, object>(VersionTableMetaData.AppliedOnColumnName, DateTime.UtcNow),
+                           new KeyValuePair<string, object>(VersionTableMetaData.AppliedOnColumnName, RawSql.Insert("CURRENT_TIMESTAMP")),
                            new KeyValuePair<string, object>(VersionTableMetaData.DescriptionColumnName, description),
                        };
         }
@@ -113,7 +113,7 @@ namespace FluentMigrator.Runner
             get
             {
                 return string.IsNullOrEmpty(VersionTableMetaData.SchemaName) ||
-					   Processor.SchemaExists(VersionTableMetaData.SchemaName);
+                       Processor.SchemaExists(VersionTableMetaData.SchemaName);
             }
         }
 
@@ -180,7 +180,7 @@ namespace FluentMigrator.Runner
             if (!AlreadyCreatedVersionTable) return;
 
             var dataSet = Processor.ReadTableData(VersionTableMetaData.SchemaName, VersionTableMetaData.TableName);
-            
+
             foreach (DataRow row in dataSet.Tables[0].Rows)
             {
                 _versionInfo.AddAppliedMigration(long.Parse(row[VersionTableMetaData.ColumnName].ToString()));

--- a/src/FluentMigrator.Tests/Unit/Expressions/ExecuteSqlStatementExpressionTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Expressions/ExecuteSqlStatementExpressionTests.cs
@@ -49,9 +49,16 @@ namespace FluentMigrator.Tests.Unit.Expressions
         }
 
         [Test]
-        public void ToStringIsDescriptive()
+        public void ToStringCanDisableOutput()
         {
             var expression = new ExecuteSqlStatementExpression() { SqlStatement = "INSERT INTO BLAH" };
+            expression.ToString().ShouldBe("");
+        }
+
+        [Test]
+        public void ToStringIsDescriptive()
+        {
+            var expression = new ExecuteSqlStatementExpression() { SqlStatement = "INSERT INTO BLAH", SayStatement = true };
             expression.ToString().ShouldBe("ExecuteSqlStatement INSERT INTO BLAH");
         }
     }

--- a/src/FluentMigrator/Builders/Execute/ExecuteExpressionRoot.cs
+++ b/src/FluentMigrator/Builders/Execute/ExecuteExpressionRoot.cs
@@ -37,7 +37,12 @@ namespace FluentMigrator.Builders.Execute
 
         public void Sql(string sqlStatement)
         {
-            var expression = new ExecuteSqlStatementExpression { SqlStatement = sqlStatement };
+            Sql(sqlStatement, false);
+        }
+
+        public void Sql(string sqlStatement, bool sayStatement)
+        {
+            var expression = new ExecuteSqlStatementExpression { SqlStatement = sqlStatement, SayStatement = sayStatement };
             _context.Expressions.Add(expression);
         }
 

--- a/src/FluentMigrator/Builders/Execute/IExecuteExpressionRoot.cs
+++ b/src/FluentMigrator/Builders/Execute/IExecuteExpressionRoot.cs
@@ -25,6 +25,7 @@ namespace FluentMigrator.Builders.Execute
     public interface IExecuteExpressionRoot : IFluentSyntax
     {
         void Sql(string sqlStatement);
+        void Sql(string sqlStatement, bool sayStatement);
         void Script(string pathToSqlScript);
         void WithConnection(Action<IDbConnection, IDbTransaction> operation);
         void EmbeddedScript(string EmbeddedSqlScriptName);

--- a/src/FluentMigrator/Expressions/ExecuteSqlStatementExpression.cs
+++ b/src/FluentMigrator/Expressions/ExecuteSqlStatementExpression.cs
@@ -26,6 +26,8 @@ namespace FluentMigrator.Expressions
     {
         public virtual string SqlStatement { get; set; }
 
+        public virtual bool SayStatement { get; set; }
+
         public override void ExecuteWith(IMigrationProcessor processor)
         {
             // since all the Processors are using String.Format() in their Execute method
@@ -42,7 +44,7 @@ namespace FluentMigrator.Expressions
 
         public override string ToString()
         {
-            return base.ToString() + SqlStatement;
+            return (SayStatement ? base.ToString() + SqlStatement : "");
         }
     }
 }


### PR DESCRIPTION
[ Issue #727 ] Added an option to Execute.Sql() to enable/disable (default=false) echoing command (comment) to output file, because command may have comments and it sometimes messes with the execution of the file.

P.S. I don't know why GitHub file comparison shows all lines being deleted and added again; diff should show only changed lines.