### PR TITLE
New GitHub wiki URL

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -4,7 +4,7 @@ Fluent Migrator is a migration framework for .NET much like Ruby on Rails Migrat
 
 h2. Project Info
 
-* *Documentation*: "http://wiki.github.com/schambers/fluentmigrator/":http://wiki.github.com/schambers/fluentmigrator/
+* *Documentation*: "https://github.com/schambers/fluentmigrator/wiki": https://github.com/schambers/fluentmigrator/wiki
 * *Discussions*: "fluentmigrator-google-group@googlegroups.com":http://groups.google.com/group/fluentmigrator-google-group
 * *Bug/Feature Tracking*: "http://github.com/schambers/fluentmigrator/issues":http://github.com/schambers/fluentmigrator/issues
 * *TeamCity sources*: "http://teamcity.codebetter.com/viewType.html?buildTypeId=bt82&tab=buildTypeStatusDiv":http://teamcity.codebetter.com/viewType.html?buildTypeId=bt82&tab=buildTypeStatusDiv


### PR DESCRIPTION
The old URL redirects to this.
