### PR TITLE
Optional NuGet package for a Log4Net announcer

### DIFF
--- a/FluentMigrator.Log4NetAnnouncer.Tests/FluentMigrator.Log4NetAnnouncer.Tests.csproj
+++ b/FluentMigrator.Log4NetAnnouncer.Tests/FluentMigrator.Log4NetAnnouncer.Tests.csproj
@@ -1,0 +1,84 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B641AE83-6214-4521-B08B-90BD5E540DB8}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FluentMigrator.Log4NetAnnouncer.Tests</RootNamespace>
+    <AssemblyName>FluentMigrator.Log4NetAnnouncer.Tests</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.5\lib\net35-full\log4net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.0.10827\lib\NET35\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.5.0\lib\net35\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Shouldly, Version=2.8.2.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
+      <HintPath>..\packages\Shouldly.2.8.2\lib\net35\Shouldly.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Log4NetAnnouncerTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\FluentMigrator.Runner\Announcers\FluentMigrator.Log4NetAnnouncer\FluentMigrator.Log4NetAnnouncer.csproj">
+      <Project>{8433bcb1-f692-42fe-824c-070e19c3f6d6}</Project>
+      <Name>FluentMigrator.Log4NetAnnouncer</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\src\FluentMigrator.Runner\FluentMigrator.Runner.csproj">
+      <Project>{cb468ad6-60c2-42e9-b3b0-01968ef94c65}</Project>
+      <Name>FluentMigrator.Runner</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/FluentMigrator.Log4NetAnnouncer.Tests/Log4NetAnnouncerTests.cs
+++ b/FluentMigrator.Log4NetAnnouncer.Tests/Log4NetAnnouncerTests.cs
@@ -1,0 +1,106 @@
+﻿using Moq;
+using NUnit.Framework;
+using Shouldly;
+using System.Text;
+using l4n = log4net;
+using l4nAnn = FluentMigrator.Runner.Announcers.Log4Net;
+
+namespace FluentMigrator.Log4NetAnnouncer.Tests
+{
+    [TestFixture]
+    public class Log4NetAnnouncerTests
+    {
+        [Test]
+        public void Instance_for_type_creates_log_for_that_type()
+        {
+            l4nAnn.Log4NetAnnouncer a = new l4nAnn.Log4NetAnnouncer(typeof(System.Threading.Thread));
+            l4n.ILog log = ReflectLogFromAnnouncer(a);
+            log.Logger.Name.ShouldBe("System.Threading.Thread");
+        }
+
+        [Test]
+        public void Instance_for_name_creates_log_with_that_name()
+        {
+            l4nAnn.Log4NetAnnouncer a = new l4nAnn.Log4NetAnnouncer("TestLogger");
+            l4n.ILog log = ReflectLogFromAnnouncer(a);
+            log.Logger.Name.ShouldBe("TestLogger");
+        }
+
+        [Test]
+        public void Instance_for_log_uses_that_log()
+        {
+            l4n.ILog log = l4n.LogManager.GetLogger("SomeCustomLogger");
+            l4nAnn.Log4NetAnnouncer a = new l4nAnn.Log4NetAnnouncer(log);
+            l4n.ILog actualLogger = ReflectLogFromAnnouncer(a);
+            actualLogger.ShouldBeSameAs(log);
+            actualLogger.Logger.Name.ShouldBe(log.Logger.Name);
+        }
+
+        [Test]
+        public void Emphasize_uses_warn_level()
+        {
+            string logMessage = "This is more important than other messages.";
+            string expectedLogMessage = "[+] " + logMessage;
+            var logMock = new Mock<l4n.ILog>();
+            logMock.Setup(l => l.Warn(It.IsAny<string>())).Verifiable();
+            l4nAnn.Log4NetAnnouncer a = new l4nAnn.Log4NetAnnouncer(logMock.Object);
+            a.Emphasize(logMessage);
+            logMock.Verify(l => l.Warn(It.Is<string>(v => v == expectedLogMessage)), Times.Once());
+        }
+
+        [Test]
+        public void Error_uses_error_level()
+        {
+            string logMessage = "This is an error messages.";
+            string errorFormat = "!!! {0}";
+            var logMock = new Mock<l4n.ILog>();
+            logMock.Setup(l => l.ErrorFormat(errorFormat, It.IsAny<string>())).Verifiable();
+            l4nAnn.Log4NetAnnouncer a = new l4nAnn.Log4NetAnnouncer(logMock.Object);
+            a.Error(logMessage);
+            logMock.Verify(l => l.ErrorFormat(errorFormat, It.Is<string>(v => v == logMessage)), Times.Once());
+        }
+
+        [Test]
+        public void Write_uses_info_level()
+        {
+            string logMessage = "This is a log message.";
+            var logMock = new Mock<l4n.ILog>();
+            logMock.Setup(l => l.Info(It.IsAny<string>())).Verifiable();
+            l4nAnn.Log4NetAnnouncer a = new l4nAnn.Log4NetAnnouncer(logMock.Object);
+            a.Write(logMessage);
+            logMock.Verify(l => l.Info(It.Is<string>(v => v == logMessage)), Times.Once());
+        }
+
+        [Test]
+        public void HorizontalRule_writes_79_dashes()
+        {
+            StringBuilder ruler = new StringBuilder();
+            for (int i = 0; i < 79; i++)
+                ruler.Append("-");
+            var logMock = new Mock<l4n.ILog>();
+            logMock.Setup(l => l.Info(It.IsAny<string>())).Verifiable();
+            l4nAnn.Log4NetAnnouncer a = new l4nAnn.Log4NetAnnouncer(logMock.Object);
+            a.HorizontalRule();
+            logMock.Verify(l => l.Info(It.Is<string>(v => v == ruler.ToString())), Times.Once());
+        }
+
+        [Test]
+        public void Heading_writes_a_banner_then_the_message()
+        {
+            string headerMessage = "This should be in the header.";
+            var logMock = new Mock<l4n.ILog>();
+            logMock.Setup(l => l.Info(It.IsAny<string>())).Verifiable();
+            l4nAnn.Log4NetAnnouncer announcer = new l4nAnn.Log4NetAnnouncer(logMock.Object);
+            announcer.Heading(headerMessage);
+            logMock.Verify(l => l.Info(It.Is<string>(v => v == headerMessage)), Times.Once());
+            logMock.Verify(l => l.Info(It.IsAny<string>()), Times.AtLeast(5));
+        }
+
+        private l4n.ILog ReflectLogFromAnnouncer(l4nAnn.Log4NetAnnouncer announcer)
+        {
+            var logMemberInfo = announcer.GetType().GetField("_log", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            l4n.ILog log = (l4n.ILog)logMemberInfo.GetValue(announcer);
+            return log;
+        }
+    }
+}

--- a/FluentMigrator.Log4NetAnnouncer.Tests/Properties/AssemblyInfo.cs
+++ b/FluentMigrator.Log4NetAnnouncer.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("FluentMigrator.Log4NetAnnouncer.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("FluentMigrator.Log4NetAnnouncer.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("b641ae83-6214-4521-b08b-90bd5e540db8")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/FluentMigrator.Log4NetAnnouncer.Tests/packages.config
+++ b/FluentMigrator.Log4NetAnnouncer.Tests/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="log4net" version="2.0.5" targetFramework="net35" />
+  <package id="Moq" version="4.0.10827" targetFramework="net35" />
+  <package id="NUnit" version="3.5.0" targetFramework="net35" />
+  <package id="Shouldly" version="2.8.2" targetFramework="net35" />
+</packages>

--- a/FluentMigrator.sln
+++ b/FluentMigrator.sln
@@ -32,6 +32,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Announcers", "Announcers", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentMigrator.Log4NetAnnouncer", "src\FluentMigrator.Runner\Announcers\FluentMigrator.Log4NetAnnouncer\FluentMigrator.Log4NetAnnouncer.csproj", "{8433BCB1-F692-42FE-824C-070E19C3F6D6}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Announcers", "Announcers", "{88C4F78F-237A-45BA-8203-AAE9DB079E0C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentMigrator.Log4NetAnnouncer.Tests", "FluentMigrator.Log4NetAnnouncer.Tests\FluentMigrator.Log4NetAnnouncer.Tests.csproj", "{B641AE83-6214-4521-B08B-90BD5E540DB8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		AutomatedRelease|Any CPU = AutomatedRelease|Any CPU
@@ -129,6 +133,18 @@ Global
 		{8433BCB1-F692-42FE-824C-070E19C3F6D6}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8433BCB1-F692-42FE-824C-070E19C3F6D6}.Release|x86.ActiveCfg = Release|Any CPU
 		{8433BCB1-F692-42FE-824C-070E19C3F6D6}.Release|x86.Build.0 = Release|Any CPU
+		{B641AE83-6214-4521-B08B-90BD5E540DB8}.AutomatedRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{B641AE83-6214-4521-B08B-90BD5E540DB8}.AutomatedRelease|Any CPU.Build.0 = Release|Any CPU
+		{B641AE83-6214-4521-B08B-90BD5E540DB8}.AutomatedRelease|x86.ActiveCfg = Release|Any CPU
+		{B641AE83-6214-4521-B08B-90BD5E540DB8}.AutomatedRelease|x86.Build.0 = Release|Any CPU
+		{B641AE83-6214-4521-B08B-90BD5E540DB8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B641AE83-6214-4521-B08B-90BD5E540DB8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B641AE83-6214-4521-B08B-90BD5E540DB8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B641AE83-6214-4521-B08B-90BD5E540DB8}.Debug|x86.Build.0 = Debug|Any CPU
+		{B641AE83-6214-4521-B08B-90BD5E540DB8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B641AE83-6214-4521-B08B-90BD5E540DB8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B641AE83-6214-4521-B08B-90BD5E540DB8}.Release|x86.ActiveCfg = Release|Any CPU
+		{B641AE83-6214-4521-B08B-90BD5E540DB8}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -143,5 +159,7 @@ Global
 		{F81E3EAB-CD44-4B55-A0EC-16F05CB45413} = {CB10ADAF-FB42-457B-ADFE-7CF866C5DA6E}
 		{3DE020D9-7040-4AC3-901A-D19AEA42538E} = {CB10ADAF-FB42-457B-ADFE-7CF866C5DA6E}
 		{8433BCB1-F692-42FE-824C-070E19C3F6D6} = {3DE020D9-7040-4AC3-901A-D19AEA42538E}
+		{88C4F78F-237A-45BA-8203-AAE9DB079E0C} = {D264186F-3ED6-482D-8E1A-F41C2F83C711}
+		{B641AE83-6214-4521-B08B-90BD5E540DB8} = {88C4F78F-237A-45BA-8203-AAE9DB079E0C}
 	EndGlobalSection
 EndGlobal

--- a/FluentMigrator.sln
+++ b/FluentMigrator.sln
@@ -1,8 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentMigrator.Runner", "src\FluentMigrator.Runner\FluentMigrator.Runner.csproj", "{CB468AD6-60C2-42E9-B3B0-01968EF94C65}"
 EndProject
@@ -28,6 +27,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentMigrator.SchemaDump", "src\FluentMigrator.SchemaDump\FluentMigrator.SchemaDump.csproj", "{F81E3EAB-CD44-4B55-A0EC-16F05CB45413}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Announcers", "Announcers", "{3DE020D9-7040-4AC3-901A-D19AEA42538E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentMigrator.Log4NetAnnouncer", "src\FluentMigrator.Runner\Announcers\FluentMigrator.Log4NetAnnouncer\FluentMigrator.Log4NetAnnouncer.csproj", "{8433BCB1-F692-42FE-824C-070E19C3F6D6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -114,6 +117,18 @@ Global
 		{F81E3EAB-CD44-4B55-A0EC-16F05CB45413}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F81E3EAB-CD44-4B55-A0EC-16F05CB45413}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F81E3EAB-CD44-4B55-A0EC-16F05CB45413}.Release|x86.ActiveCfg = Release|Any CPU
+		{8433BCB1-F692-42FE-824C-070E19C3F6D6}.AutomatedRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{8433BCB1-F692-42FE-824C-070E19C3F6D6}.AutomatedRelease|Any CPU.Build.0 = Release|Any CPU
+		{8433BCB1-F692-42FE-824C-070E19C3F6D6}.AutomatedRelease|x86.ActiveCfg = Release|Any CPU
+		{8433BCB1-F692-42FE-824C-070E19C3F6D6}.AutomatedRelease|x86.Build.0 = Release|Any CPU
+		{8433BCB1-F692-42FE-824C-070E19C3F6D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8433BCB1-F692-42FE-824C-070E19C3F6D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8433BCB1-F692-42FE-824C-070E19C3F6D6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8433BCB1-F692-42FE-824C-070E19C3F6D6}.Debug|x86.Build.0 = Debug|Any CPU
+		{8433BCB1-F692-42FE-824C-070E19C3F6D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8433BCB1-F692-42FE-824C-070E19C3F6D6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8433BCB1-F692-42FE-824C-070E19C3F6D6}.Release|x86.ActiveCfg = Release|Any CPU
+		{8433BCB1-F692-42FE-824C-070E19C3F6D6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -126,5 +141,7 @@ Global
 		{C2B629E5-9394-48DA-A9E8-4999B398F37E} = {CB10ADAF-FB42-457B-ADFE-7CF866C5DA6E}
 		{97849F97-BD7D-453B-B0CF-6CD922BB1596} = {CB10ADAF-FB42-457B-ADFE-7CF866C5DA6E}
 		{F81E3EAB-CD44-4B55-A0EC-16F05CB45413} = {CB10ADAF-FB42-457B-ADFE-7CF866C5DA6E}
+		{3DE020D9-7040-4AC3-901A-D19AEA42538E} = {CB10ADAF-FB42-457B-ADFE-7CF866C5DA6E}
+		{8433BCB1-F692-42FE-824C-070E19C3F6D6} = {3DE020D9-7040-4AC3-901A-D19AEA42538E}
 	EndGlobalSection
 EndGlobal

--- a/src/FluentMigrator.Runner/Announcers/FluentMigrator.Log4NetAnnouncer/FluentMigrator.Log4NetAnnouncer.csproj
+++ b/src/FluentMigrator.Runner/Announcers/FluentMigrator.Log4NetAnnouncer/FluentMigrator.Log4NetAnnouncer.csproj
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8433BCB1-F692-42FE-824C-070E19C3F6D6}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FluentMigrator.Runner.Announcers.Log4Net</RootNamespace>
+    <AssemblyName>FluentMigrator.Log4NetAnnouncer</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AutomatedRelease|AnyCPU' ">
+    <OutputPath>..\..\..\build\AutomatedRelease\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <CodeAnalysisUseTypeNameInSuppression>true</CodeAnalysisUseTypeNameInSuppression>
+    <CodeAnalysisModuleSuppressionsFile>GlobalSuppressions.cs</CodeAnalysisModuleSuppressionsFile>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\log4net.2.0.5\lib\net35-full\log4net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\..\SolutionInfo.cs">
+      <Link>Properties\SolutionInfo.cs</Link>
+    </Compile>
+    <Compile Include="Log4NetAnnouncer.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\FluentMigrator.Runner.csproj">
+      <Project>{cb468ad6-60c2-42e9-b3b0-01968ef94c65}</Project>
+      <Name>FluentMigrator.Runner</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/FluentMigrator.Runner/Announcers/FluentMigrator.Log4NetAnnouncer/FluentMigrator.Log4NetAnnouncer.csproj
+++ b/src/FluentMigrator.Runner/Announcers/FluentMigrator.Log4NetAnnouncer/FluentMigrator.Log4NetAnnouncer.csproj
@@ -70,6 +70,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="readme.txt" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/FluentMigrator.Runner/Announcers/FluentMigrator.Log4NetAnnouncer/FluentMigrator.Log4NetAnnouncer.nuspec
+++ b/src/FluentMigrator.Runner/Announcers/FluentMigrator.Log4NetAnnouncer/FluentMigrator.Log4NetAnnouncer.nuspec
@@ -21,5 +21,6 @@
   <files>
     <file src="bin\Release\FluentMigrator.Log4NetAnnouncer.dll" target="lib\35" />
     <file src="bin\Release\FluentMigrator.Log4NetAnnouncer.pdb" target="lib\35" />
+    <file src="readme.txt" target="" />
   </files>
 </package>

--- a/src/FluentMigrator.Runner/Announcers/FluentMigrator.Log4NetAnnouncer/FluentMigrator.Log4NetAnnouncer.nuspec
+++ b/src/FluentMigrator.Runner/Announcers/FluentMigrator.Log4NetAnnouncer/FluentMigrator.Log4NetAnnouncer.nuspec
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>FluentMigrator.Log4NetAnnouncer</id>
+    <version>1.6.2</version>
+    <authors>Josh Coffman, Tom Marien</authors>
+    <owners>Sean Chambers</owners>
+    <licenseUrl>https://github.com/schambers/fluentmigrator/blob/master/LICENSE.txt</licenseUrl>
+    <projectUrl>https://github.com/schambers/fluentmigrator/wiki/</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version.
+      In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</description>
+    <summary>FluentMigrator is a database migration framework for .NET written in C#.</summary>
+    <releaseNotes>https://github.com/schambers/fluentmigrator/releases</releaseNotes>
+    <language>en-US</language>
+    <dependencies>
+      <dependency id="FluentMigrator.Runner" version="1.6.2" />
+      <dependency id="log4net" version="2.0.5" />      
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="bin\Release\FluentMigrator.Log4NetAnnouncer.dll" target="lib\35" />
+    <file src="bin\Release\FluentMigrator.Log4NetAnnouncer.pdb" target="lib\35" />
+  </files>
+</package>

--- a/src/FluentMigrator.Runner/Announcers/FluentMigrator.Log4NetAnnouncer/Log4NetAnnouncer.cs
+++ b/src/FluentMigrator.Runner/Announcers/FluentMigrator.Log4NetAnnouncer/Log4NetAnnouncer.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 
 namespace FluentMigrator.Runner.Announcers.Log4Net
 {
-    public class Log4NetAnnouncer : IAnnouncer
+    public class Log4NetAnnouncer : Announcer
     {
         private readonly log4net.ILog _log;
 
@@ -36,35 +36,22 @@ namespace FluentMigrator.Runner.Announcers.Log4Net
         { }
 
         public Log4NetAnnouncer(log4net.ILog log)
+            : base()
         {
             _log = log;
         }
 
-        public void ElapsedTime(TimeSpan timeSpan)
+        public override void Emphasize(string message)
         {
-            Write(string.Format("=> {0}s", timeSpan.TotalSeconds), true);
+            _log.Warn(string.Format("[+] {0}", message));
         }
 
-        public void Emphasize(string message)
-        {
-            Say(string.Format("[+] {0}", message));
-        }
-
-        public void Error(Exception exception)
-        {
-            while (exception != null)
-            {
-                Error(exception.Message);
-                exception = exception.InnerException;
-            }
-        }
-
-        public void Error(string message)
+        public override void Error(string message)
         {
             _log.ErrorFormat("!!! {0}", message);
         }
 
-        public void Heading(string message)
+        public override void Heading(string message)
         {
             HorizontalRule();
             Write("=============================== FluentMigrator ================================");
@@ -76,20 +63,7 @@ namespace FluentMigrator.Runner.Announcers.Log4Net
             HorizontalRule();
         }
 
-        public void Say(string message)
-        {
-            Write(message);
-        }
-
-        public void Sql(string sql)
-        {
-            if (string.IsNullOrEmpty(sql))
-                Write("No SQL statement executed.", true);
-            else
-                Write(sql, false);
-        }
-
-        public void Write(string message, bool escaped)
+        public override void Write(string message, bool escaped)
         {
             _log.Info(message);
         }

--- a/src/FluentMigrator.Runner/Announcers/FluentMigrator.Log4NetAnnouncer/Log4NetAnnouncer.cs
+++ b/src/FluentMigrator.Runner/Announcers/FluentMigrator.Log4NetAnnouncer/Log4NetAnnouncer.cs
@@ -61,6 +61,7 @@ namespace FluentMigrator.Runner.Announcers.Log4Net
             Write("Ask For Help:");
             Write("  http://groups.google.com/group/fluentmigrator-google-group");
             HorizontalRule();
+            Write(message);
         }
 
         public override void Write(string message, bool escaped)
@@ -68,7 +69,7 @@ namespace FluentMigrator.Runner.Announcers.Log4Net
             _log.Info(message);
         }
 
-        public void HorizontalRule()
+        public virtual void HorizontalRule()
         {
             Write("".PadRight(79, '-'));
         }

--- a/src/FluentMigrator.Runner/Announcers/FluentMigrator.Log4NetAnnouncer/Log4NetAnnouncer.cs
+++ b/src/FluentMigrator.Runner/Announcers/FluentMigrator.Log4NetAnnouncer/Log4NetAnnouncer.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Reflection;
+
+namespace FluentMigrator.Runner.Announcers.Log4Net
+{
+    public class Log4NetAnnouncer : IAnnouncer
+    {
+        private readonly log4net.ILog _log;
+
+        public Log4NetAnnouncer()
+            : this(MethodBase.GetCurrentMethod().DeclaringType)
+        { }
+
+        public Log4NetAnnouncer(Type loggerType)
+            : this(log4net.LogManager.GetLogger(loggerType))
+        { }
+
+        public Log4NetAnnouncer(string loggerName)
+            : this(log4net.LogManager.GetLogger(loggerName))
+        { }
+
+        public Log4NetAnnouncer(string repository, Type loggerType)
+            : this(log4net.LogManager.GetLogger(repository, loggerType))
+        { }
+
+        public Log4NetAnnouncer(string repository, string loggerName)
+            : this(log4net.LogManager.GetLogger(repository, loggerName))
+        { }
+
+        public Log4NetAnnouncer(Assembly repositoryAssembly, Type loggerType)
+            : this(log4net.LogManager.GetLogger(repositoryAssembly, loggerType))
+        { }
+
+        public Log4NetAnnouncer(Assembly repositoryAssembly, string loggerName)
+            : this(log4net.LogManager.GetLogger(repositoryAssembly, loggerName))
+        { }
+
+        public Log4NetAnnouncer(log4net.ILog log)
+        {
+            _log = log;
+        }
+
+        public void ElapsedTime(TimeSpan timeSpan)
+        {
+            Write(string.Format("=> {0}s", timeSpan.TotalSeconds), true);
+        }
+
+        public void Emphasize(string message)
+        {
+            Say(string.Format("[+] {0}", message));
+        }
+
+        public void Error(Exception exception)
+        {
+            while (exception != null)
+            {
+                Error(exception.Message);
+                exception = exception.InnerException;
+            }
+        }
+
+        public void Error(string message)
+        {
+            _log.ErrorFormat("!!! {0}", message);
+        }
+
+        public void Heading(string message)
+        {
+            HorizontalRule();
+            Write("=============================== FluentMigrator ================================");
+            HorizontalRule();
+            Write("Source Code:");
+            Write("  http://github.com/schambers/fluentmigrator");
+            Write("Ask For Help:");
+            Write("  http://groups.google.com/group/fluentmigrator-google-group");
+            HorizontalRule();
+        }
+
+        public void Say(string message)
+        {
+            Write(message);
+        }
+
+        public void Sql(string sql)
+        {
+            if (string.IsNullOrEmpty(sql))
+                Write("No SQL statement executed.", true);
+            else
+                Write(sql, false);
+        }
+
+        public void Write(string message, bool escaped)
+        {
+            _log.Info(message);
+        }
+
+        public void HorizontalRule()
+        {
+            Write("".PadRight(79, '-'));
+        }
+
+        public void Write(string message)
+        {
+            Write(message, true);
+        }
+    }
+}

--- a/src/FluentMigrator.Runner/Announcers/FluentMigrator.Log4NetAnnouncer/Properties/AssemblyInfo.cs
+++ b/src/FluentMigrator.Runner/Announcers/FluentMigrator.Log4NetAnnouncer/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("FluentMigrator.Log4NetAnnouncer")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("8433bcb1-f692-42fe-824c-070e19c3f6d6")]

--- a/src/FluentMigrator.Runner/Announcers/FluentMigrator.Log4NetAnnouncer/packages.config
+++ b/src/FluentMigrator.Runner/Announcers/FluentMigrator.Log4NetAnnouncer/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="log4net" version="2.0.5" targetFramework="net35" />
+</packages>

--- a/src/FluentMigrator.Runner/Announcers/FluentMigrator.Log4NetAnnouncer/readme.txt
+++ b/src/FluentMigrator.Runner/Announcers/FluentMigrator.Log4NetAnnouncer/readme.txt
@@ -1,0 +1,56 @@
+﻿To use Log4NetAnnouncer with XML configuration of log4net,
+remember to add an assembly attribute below the using statements 
+in your main assembly:
+[assembly: log4net.Config.XmlConfigurator(Watch = true)]
+
+Sample configuration of log4net to configure a console appender:
+  <configSections>
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net"/>
+  </configSections>
+  ...
+  <log4net>
+    <root>
+      <level value="DEBUG"/>
+      <appender-ref ref="ConsoleAppender" />
+    </root>
+    <appender name="ConsoleAppender" type="log4net.Appender.ColoredConsoleAppender">
+      <mapping>
+        <level value="INFO" />
+        <foreColor value="Green, HighIntensity" />
+      </mapping>
+      <mapping>
+        <level value="DEBUG" />
+        <foreColor value="Cyan, HighIntensity" />
+      </mapping>
+      <mapping>
+        <level value="WARN" />
+        <foreColor value="Yellow, HighIntensity" />
+      </mapping>
+      <mapping>
+        <level value="ERROR" />
+        <foreColor value="Red, HighIntensity" />
+      </mapping>
+      <layout type="log4net.Layout.PatternLayout">
+        <conversionPattern value="%message%newline" />
+      </layout>
+    </appender>
+  </log4net>
+
+Sample configuration of log4net to configure a file appender:
+  <log4net>
+    <root>
+      <level value="DEBUG"/>
+      <appender-ref ref="RollingFileAppender" />
+    </root>
+    <appender name="RollingFileAppender" type="log4net.Appender.RollingFileAppender">
+      <file value="log.txt" />
+      <appendToFile value="true" />
+      <rollingStyle value="Size" />
+      <maxSizeRollBackups value="10" />
+      <maximumFileSize value="1MB" />
+      <staticLogFileName value="true" />
+      <layout type="log4net.Layout.PatternLayout">
+          <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+      </layout>
+    </appender>
+  </log4net>


### PR DESCRIPTION
After writing a Log4Net announcer for a few projects, maybe it's a good idea to build it into an optional NuGet package distributed like the other official FluentMigrator packages.

Hope it provides enough flexibility. I've assumed INFO is the desired log level for typical messages, WARN for emphasized messages and ERROR for error messages.

This is related to issue #680. 